### PR TITLE
Creating Ltac for Proofs Cleanup

### DIFF
--- a/fma_floating_point_model.v
+++ b/fma_floating_point_model.v
@@ -10,7 +10,6 @@ Set Bullet Behavior "Strict Subproofs".
 
 Require Import floatlib.
 
-
 Section WITHNANS.
 Context {NANS: Nans}. 
 
@@ -143,7 +142,6 @@ Notation "-f A" := (opp_mat A) (at level 50).
 Notation "A *f B" := (mulmx_float A B) (at level 70).
 Notation "A -f B" := (sub_mat A B) (at level 80).
 
-
 Definition A1_inv_J {ty} {n:nat} (A: 'M[ftype ty]_n.+1) : 'cV[ftype ty]_n.+1 :=
   \col_i (BDIV (Zconst ty 1) (A i i)).
 
@@ -168,21 +166,19 @@ Definition X_m_jacobi {ty} {n:nat} m x0 b (A: 'M[ftype ty]_n.+1) :
   'cV[ftype ty]_n.+1 :=
    Nat.iter m  (fun x0 => jacobi_iter x0 b A) x0.
 
-
-Definition matrix_inj' {t} (A: matrix t) m n  d d': 'M[ftype t]_(m,n):=
-    \matrix_(i < m, j < n) 
-     nth j (nth i A d) d'.
-
-Definition matrix_inj {t} (A: matrix t) m n  : 'M[ftype t]_(m,n):=
-  matrix_inj' A m n [::] (Zconst t 0).
-
-Definition vector_inj' {t} (v: vector t) n d : 'cV[ftype t]_n :=
-   \col_(i < n) nth i v d.
-
-Definition vector_inj {t} (v: vector t) n : 'cV[ftype t]_n :=
-   vector_inj' v n (Zconst t 0).
+(*unit vector with ith-element = 1*)
+Definition e_i {n : nat} {ty} (i : 'I_n.+1) : 'cV[ftype ty]_n.+1 :=
+\col_(j < n.+1) (if j == i then (Zconst ty 1) else (Zconst ty 0)).
 
 
+(* Approximate solving for a column of A^-1 using m Jacobi iterations *)
+Definition ith_col_A_inv {ty} {n : nat} m x0 (A : 'M[ftype ty]_n.+1) (i : 'I_n.+1): 'cV[ftype ty]_n.+1  :=
+  let b := e_i i in
+  X_m_jacobi m x0 b A.
+
+(* Define the approximate inverse of A after m Jacobi iterations *)
+Definition A_inv_jacobi {ty} {n : nat} m (x0 : 'cV[ftype ty]_n.+1) (A : 'M[ftype ty]_n.+1) : 'M[ftype ty]_n.+1 :=
+  (\matrix_(i < n.+1) (ith_col_A_inv m x0 A i)^T)^T.
 
 Lemma length_veclist {ty} {n m:nat} (v: 'cV[ftype ty]_n.+1):
   length (@vec_to_list_float _ n m v) = m.

--- a/fma_jacobi_forward_error.v
+++ b/fma_jacobi_forward_error.v
@@ -713,8 +713,7 @@ Definition input_bound {t} {n:nat}
 
 Lemma rho_def_power_le_one {t : type} {n : nat} (A : 'M[ftype t]_n.+1) (b : 'cV[ftype t]_n.+1) (k : nat) :
   let rho := rho_def A b in
-  (rho < 1)%Re ->
-  (rho ^ k <= 1)%Re.
+  (rho < 1)%Re -> (rho ^ k <= 1)%Re.
 Proof.
   intros rho H0.
   assert (1%Re = (1 ^ k)%Re) by (rewrite pow1; nra).
@@ -889,7 +888,6 @@ apply Rle_lt_trans with
     apply Rplus_le_compat.
     * apply Rplus_le_compat_l.
       apply Rmult_le_compat_r. unfold f_error. apply /RleP. apply vec_norm_pd. 
-      Check @rho_def_power_le_one.
       apply (@rho_def_power_le_one ty n A b k H0).
       * apply Rho_dmag_Bound. apply H0.
 + apply bnd4.
@@ -1611,18 +1609,6 @@ induction k.
                                 assert ((n.+1 - j.+1)%coq_nat = (n.+1.-1 - j)%coq_nat).
                                 { lia. } rewrite H5 in Hnth. 
                                 apply (finite_BPLUS_BOPP Hnth Hlength Hfin).
-                                (* rewrite !nth_vec_to_list_float in Hnth.
-                                rewrite -Hnth /=.
-                                specialize (Hfin (@inord n j)).
-                                rewrite mxE in Hfin. rewrite !nth_vec_to_list_float in Hfin.
-                                rewrite inord_val in Hfin. repeat split; try apply Hfin.
-                                1,2,3: apply BMULT_finite_e in Hfin; destruct Hfin as [Hfin1 Hfin2]; rewrite mxE in Hfin2; apply Bminus_bplus_opp_implies in Hfin2.
-                                2: apply BPLUS_finite_e in Hfin2; rewrite finite_BOPP in Hfin2.
-                                1,2,3: try apply Hfin2.
-                                1,2,3: by rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
-                                1,2: rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength;
-                                by apply /ssrnat.ltP. 
-                                by rewrite !length_veclist. *)
                              ++++ by rewrite rev_length in Hlength.
                             } apply reverse_triang_ineq in H4.
                             apply Rle_trans with 
@@ -1791,27 +1777,6 @@ induction k.
                               ---- rewrite combine_length !length_veclist Nat.min_id in Hnth.
                                    assert ((n.+1 - j.+1)%coq_nat = (n.+1.-1 - j)%coq_nat).
                                   { lia. } rewrite H5 in Hnth. apply (finite_BPLUS_BOPP Hnth Hlength Hfin).
-                                   (* { lia. } rewrite H5 in Hnth. rewrite combine_nth in Hnth.
-                                   rewrite !nth_vec_to_list_float in Hnth.
-                                   rewrite -Hnth /=.
-                                   specialize (Hfin (@inord n j)).
-                                   rewrite mxE in Hfin. rewrite !nth_vec_to_list_float in Hfin.
-                                   rewrite inord_val in Hfin. repeat split; try apply Hfin.
-                                   apply BMULT_finite_e in Hfin. destruct Hfin as [Hfin1 Hfin2].
-                                   rewrite mxE in Hfin2. apply Bminus_bplus_opp_implies  in Hfin2.
-                                   apply BPLUS_finite_e in Hfin2; try apply Hfin2.
-                                   apply BMULT_finite_e in Hfin. destruct Hfin as [Hfin1 Hfin2].
-                                   rewrite mxE in Hfin2. apply Bminus_bplus_opp_implies  in Hfin2.
-                                   apply BPLUS_finite_e in Hfin2. rewrite finite_BOPP in Hfin2.  try apply Hfin2.
-                                   apply BMULT_finite_e in Hfin. destruct Hfin as [Hfin1 Hfin2].
-                                   rewrite mxE in Hfin2. apply Bminus_bplus_opp_implies  in Hfin2.
-                                   try apply Hfin2.
-                                   by rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
-                                   by rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
-                                   rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
-                                   by apply /ssrnat.ltP.
-                                   rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
-                                   by apply /ssrnat.ltP. by rewrite !length_veclist. *)
                              ---- by rewrite rev_length in Hlength.
                ++++ assert (A2_J_real (FT2R_mat A) = FT2R_mat (A2_J A)).
                     { apply matrixP. unfold eqrel. intros. rewrite !mxE.

--- a/inf_norm_properties.v
+++ b/inf_norm_properties.v
@@ -312,13 +312,6 @@ apply /RleP. apply bigmax_le.
   - by rewrite size_map size_enum_ord in H.
 Qed.
 
-
-(* Ltac apply_seq H0 A j n i0 i:= rewrite H0; apply /RleP; apply (@bigmaxr_ler _ 0 [seq \sum_(j < n.+1) Rabs (A i0 j)
-| i0 <- enum 'I_n.+1] i).
-
-Ltac seq_rewrite' H H0 A j n i0 i:=  rewrite seq_equiv; rewrite nth_mkseq; try by []; try by rewrite size_map size_enum_ord in H; 
-apply_seq H0 A j n i0 i; rewrite size_map size_enum_ord in H; by rewrite size_map size_enum_ord. *)
-
 Lemma matrix_norm_add {n:nat}:
   forall (A B : 'M[R]_n.+1),
   matrix_inf_norm (A + B) <= matrix_inf_norm A + matrix_inf_norm B.

--- a/inf_norm_properties.v
+++ b/inf_norm_properties.v
@@ -54,7 +54,7 @@ split.
   by rewrite size_map size_enum_ord in H. 
 Qed.
 
-
+Ltac seq_rewrite := unfold mkseq; rewrite -val_enum_ord; rewrite -[in RHS]map_comp ;apply eq_map; unfold eqfun; intros.
 
 Lemma triang_ineq {n:nat} : forall a b: 'cV[R]_n.+1,
 vec_inf_norm(a + b) <= vec_inf_norm a + vec_inf_norm b.
@@ -69,33 +69,25 @@ apply bigmax_le.
      [seq Rabs (b i0 0) | i0 <- enum 'I_n.+1]`_i)%Re.
   - assert ([seq Rabs ((a + b)%Ri i0 0) | i0 <- enum 'I_n.+1] = 
                mkseq (fun i =>  Rabs ((a + b)%Ri (@inord n i) 0)) n.+1).
-    { unfold mkseq. rewrite -val_enum_ord.
-      rewrite -[in RHS]map_comp.
-      apply eq_map. unfold eqfun. intros.
-      rewrite !mxE //=. rewrite !mxE. by rewrite inord_val.
+    { 
+      seq_rewrite. rewrite !mxE //=. rewrite !mxE. by rewrite inord_val.
     } rewrite H0 nth_mkseq; last by rewrite size_map size_enum_ord in H.  
     assert ([seq Rabs (a i0 0) | i0 <- enum 'I_n.+1] = 
                mkseq (fun i =>  Rabs (a (@inord n i) 0)) n.+1).
-    { unfold mkseq. rewrite -val_enum_ord.
-      rewrite -[in RHS]map_comp.
-      apply eq_map. unfold eqfun. intros. by rewrite //= inord_val //=.
+    { 
+      seq_rewrite. by rewrite //= inord_val //=.
     } rewrite H1 nth_mkseq ; last by rewrite size_map size_enum_ord in H.
     assert ([seq Rabs (b i0 0) | i0 <- enum 'I_n.+1] = 
                mkseq (fun i =>  Rabs (b (@inord n i) 0)) n.+1).
-    { unfold mkseq. rewrite -val_enum_ord.
-      rewrite -[in RHS]map_comp.
-      apply eq_map. unfold eqfun. intros. by rewrite //= inord_val //=.
+    { 
+      seq_rewrite. by rewrite //= inord_val //=.
     } rewrite H2 nth_mkseq ; last by rewrite size_map size_enum_ord in H.
     rewrite !mxE //=. rewrite -RplusE. apply Rabs_triang.
   - apply Rplus_le_compat.
-    * apply /RleP. 
-      apply (@bigmaxr_ler _ 0%Re [seq Rabs (a i0 0) | i0 <- enum 'I_n.+1] i).
-      rewrite size_map size_enum_ord.
-      by rewrite size_map size_enum_ord in H.
-    * apply /RleP. 
-      apply (@bigmaxr_ler _ 0%Re [seq Rabs (b i0 0) | i0 <- enum 'I_n.+1] i).
-      rewrite size_map size_enum_ord.
-      by rewrite size_map size_enum_ord in H.
+      all: apply /RleP.
+      1: apply (@bigmaxr_ler _ 0%Re [seq Rabs (a i0 0) | i0 <- enum 'I_n.+1] i).
+      2: apply (@bigmaxr_ler _ 0%Re [seq Rabs (b i0 0) | i0 <- enum 'I_n.+1] i).
+      all: (rewrite size_map size_enum_ord; by rewrite size_map size_enum_ord in H).
 Qed.
 
 
@@ -116,20 +108,16 @@ rewrite -bigmaxr_mulr.
       | i0 <- enum 'I_n.+1]`_i.
     * assert ([seq Rabs ((A *m v) i0 0) | i0 <- enum 'I_n.+1] = 
               mkseq (fun i => Rabs ((A *m v) (@inord n i) 0)) n.+1).
-      { unfold mkseq. rewrite -val_enum_ord.
-        rewrite -[in RHS]map_comp.
-        apply eq_map. unfold eqfun. intros.
-        rewrite !mxE //=. rewrite !mxE. by rewrite //= inord_val //=.
+      { 
+        seq_rewrite. rewrite !mxE //=. rewrite !mxE. by rewrite //= inord_val //=.
       } rewrite H0 nth_mkseq ; last by rewrite size_map size_enum_ord in H.
       assert ([seq bigmaxr 0
                   [seq Rabs (v i1 0) | i1 <- enum 'I_n.+1] *  row_sum A i0
                     | i0 <- enum 'I_n.+1] = 
                mkseq (fun i =>  bigmaxr 0  
                         [seq Rabs (v i1 0) | i1 <- enum 'I_n.+1] *  row_sum A (@inord n i)) n.+1).
-      { unfold mkseq. rewrite -val_enum_ord.
-        rewrite -[in RHS]map_comp.
-        apply eq_map. unfold eqfun. intros.
-        by rewrite //= inord_val //=.
+      { 
+        seq_rewrite. by rewrite //= inord_val //=.
       } rewrite H1 nth_mkseq ; last by rewrite size_map size_enum_ord in H.
       rewrite -RmultE. rewrite !mxE.
       apply Rle_trans with 
@@ -148,10 +136,8 @@ rewrite -bigmaxr_mulr.
          -- apply Rle_trans with [seq Rabs (v i1 0) | i1 <- enum 'I_n.+1]`_i0.
             ** assert ([seq Rabs (v i1 0) | i1 <- enum 'I_n.+1] = 
                        mkseq (fun i => Rabs (v (@inord n i) 0)) n.+1).
-               { unfold mkseq. rewrite -val_enum_ord.
-                 rewrite -[in RHS]map_comp.
-                 apply eq_map. unfold eqfun. intros.
-                 by rewrite //= inord_val //=.
+               { 
+                 seq_rewrite. by rewrite //= inord_val //=.
                } rewrite H4 nth_mkseq ; last by rewrite size_map size_enum_ord in H. 
                rewrite //= inord_val. nra.
             ** apply /RleP. apply (@bigmaxr_ler _ 0%Re [seq Rabs (v i1 0) | i1 <- enum 'I_n.+1] i0).
@@ -172,10 +158,8 @@ rewrite -bigmaxr_mulr.
   - intros. 
     assert ([seq Rabs (v i0 0) | i0 <- enum 'I_n.+1]= 
               mkseq (fun i => Rabs (v (@inord n i) 0)) n.+1).
-    { unfold mkseq. rewrite -val_enum_ord.
-      rewrite -[in RHS]map_comp.
-      apply eq_map. unfold eqfun. intros.
-      by rewrite //= inord_val //=.
+    { 
+      seq_rewrite. by rewrite //= inord_val //=.
     } rewrite H0 nth_mkseq ; last by rewrite size_map size_enum_ord in H.
     unfold row_sum. apply /RleP. apply Rabs_pos.
 Qed.
@@ -289,6 +273,7 @@ apply /RleP. apply bigmax_le.
                      (Rabs (A (inord i) k) * Rabs (B k j))%Re).
       { apply exchange_big. } rewrite H0. 
       rewrite mulrC. rewrite -bigmaxr_mulr.
+
       apply Rle_trans with 
       (nth 0 [seq (bigmaxr 0 [seq \sum_(j < n.+1) Rabs (B i1 j)
                       | i1 <- enum 'I_n.+1] *
@@ -328,9 +313,16 @@ apply /RleP. apply bigmax_le.
 Qed.
 
 
+(* Ltac apply_seq H0 A j n i0 i:= rewrite H0; apply /RleP; apply (@bigmaxr_ler _ 0 [seq \sum_(j < n.+1) Rabs (A i0 j)
+| i0 <- enum 'I_n.+1] i).
+
+Ltac seq_rewrite' H H0 A j n i0 i:=  rewrite seq_equiv; rewrite nth_mkseq; try by []; try by rewrite size_map size_enum_ord in H; 
+apply_seq H0 A j n i0 i; rewrite size_map size_enum_ord in H; by rewrite size_map size_enum_ord. *)
+
 Lemma matrix_norm_add {n:nat}:
   forall (A B : 'M[R]_n.+1),
   matrix_inf_norm (A + B) <= matrix_inf_norm A + matrix_inf_norm B.
+
 Proof.
 intros. rewrite /matrix_inf_norm.
 apply /RleP. apply bigmax_le.
@@ -354,9 +346,10 @@ apply /RleP. apply bigmax_le.
            + by rewrite size_map size_enum_ord in H.
          } rewrite H0. apply /RleP.
          apply (@bigmaxr_ler _ 0 [seq \sum_(j < n.+1) Rabs (A i0 j)
-                                      | i0 <- enum 'I_n.+1] i).
-         rewrite size_map size_enum_ord in H.
+                                      | i0 <- enum 'I_n.+1] i). 
+          rewrite size_map size_enum_ord in H.
          by rewrite size_map size_enum_ord.
+         (* seq_rewrite' H H0 A j n i0 i.  *)
       ++ assert (\sum_(j < n.+1) Rabs (B (inord i) j) = 
                   nth 0 [seq \sum_(j < n.+1) Rabs (B i0 j)
                             | i0 <- enum 'I_n.+1] i).
@@ -368,6 +361,7 @@ apply /RleP. apply bigmax_le.
                                       | i0 <- enum 'I_n.+1] i).
          rewrite size_map size_enum_ord in H.
          by rewrite size_map size_enum_ord.
+         (* seq_rewrite' H H0 B j n i0 i. *)
   - by rewrite size_map size_enum_ord in H.
 Qed.
 

--- a/jacob_list_fun_model.v
+++ b/jacob_list_fun_model.v
@@ -307,6 +307,8 @@ apply (IHm1 m2 (length a)); auto.
 lia.
 Qed.
 
+Ltac temp1 := try (rewrite matrix_by_index_rows);  try (rewrite length_diag_of_matrix); auto.
+(* Ltac temp2 := apply matrix_by_index_cols; apply length_diag_of_matrix; auto. *)
 Lemma remove_plus_diag: forall {t} (m: matrix t),
    matrix_cols_nat m (matrix_rows_nat m) ->
    Forall (Forall finite) m ->
@@ -316,28 +318,32 @@ intros.
 apply matrix_extensionality with (cols := matrix_rows_nat m); auto.
 unfold matrix_add.
 rewrite matrix_rows_nat_matrix_binop.
-unfold matrix_of_diag.
+1,2: unfold matrix_of_diag; temp1.
+unfold remove_diag. temp1.
+(* unfold matrix_of_diag.
 rewrite matrix_by_index_rows.
-apply length_diag_of_matrix; auto.
-unfold matrix_of_diag.
+apply length_diag_of_matrix; auto. *)
+(* unfold matrix_of_diag.
 rewrite matrix_by_index_rows.
-rewrite length_diag_of_matrix; auto.
-unfold remove_diag.
-rewrite matrix_by_index_rows; auto.
+rewrite length_diag_of_matrix; auto. *)
+(* rewrite matrix_by_index_rows; auto. *)
 apply matrix_cols_nat_matrix_binop.
 replace (matrix_rows_nat m) with (length (diag_of_matrix m)).
 apply matrix_by_index_cols.
 apply length_diag_of_matrix; auto.
+(* temp2. *)
 apply matrix_by_index_cols.
-unfold matrix_add at 1.
+unfold matrix_add at 1. 
 rewrite matrix_rows_nat_matrix_binop.
 2:{ unfold matrix_of_diag. rewrite matrix_by_index_rows.
-    unfold remove_diag.  rewrite matrix_by_index_rows.
-    apply length_diag_of_matrix; auto.
+    unfold remove_diag. temp1.
+    (*  rewrite matrix_by_index_rows.
+    apply length_diag_of_matrix; auto. *)
 }
 unfold matrix_of_diag at 1.
-rewrite matrix_by_index_rows; auto.
-rewrite length_diag_of_matrix; auto.
+temp1; temp1.
+(* rewrite matrix_by_index_rows; auto.
+rewrite length_diag_of_matrix; auto. *)
 intros.
 unfold matrix_add.
 rewrite binop_matrix_index with (cols := matrix_rows_nat m); auto.


### PR DESCRIPTION
Refactored repetitive proofs by using Ltac and goal selectors in jacob_list_fun_model, inf_norm_properties, and mostly in fma_jacobi_foward_error. 