### PR TITLE
Fixing deprecations

### DIFF
--- a/bound_on_x.v
+++ b/bound_on_x.v
@@ -120,10 +120,11 @@ Lemma vec_norm_A1_rel {t: FPStdLib.type} {n:nat}
 (vec_inf_norm (A1_diag (FT2R_mat A))  <=
  (vec_inf_norm (FT2R_mat (A1_inv_J A)) + default_abs t) / (1 - default_rel t) )%Re.
 Proof.
-unfold vec_inf_norm.
-apply bigmax_le.
-+ by rewrite size_map size_enum_ord.
-+ intros.
+  rewrite /vec_inf_norm. apply bigmax_le_0head.
+  { rewrite size_map size_enum_ord. by []. }
+  2:{ intros. move /mapP in H. destruct H as [i H1 H2]. 
+    rewrite H2. apply /RleP. apply Rabs_pos. } 
+  intros.
   rewrite seq_equiv. rewrite nth_mkseq;
   last by rewrite size_map size_enum_ord in H.
   rewrite mxE.
@@ -154,14 +155,13 @@ apply bigmax_le.
     apply Rplus_le_compat_l. 
     apply Ropp_le_contravar. apply Hd.
     apply Ropp_le_contravar. apply He.
-  - apply /RleP.
-    apply (@bigmaxr_ler _ 0%Re [seq Rabs
-                                   (FT2R_mat (A1_inv_J A) i0 0)
-                               | i0 <- enum 'I_n.+1] i).
-    rewrite size_map size_enum_ord.
-    by rewrite size_map size_enum_ord in H.
+  - apply bigmax_ler_0head.
+    { apply /mapP. exists (inord i). apply mem_enum.
+      rewrite seq_equiv. rewrite nth_mkseq; 
+      last by rewrite size_map size_enum_ord in H. reflexivity. }
+    intros. move /mapP in H0. destruct H0 as [i0 H1 H2]. rewrite H2.
+    apply /RleP. apply Rabs_pos.
 Qed.
-
 
 Lemma R_def_lt_1_implies {t} {n:nat}
   (A : 'M[ftype t]_n.+1) 
@@ -402,20 +402,15 @@ intros.
 induction k.
 + simpl. rewrite big_ord0 /= Rmult_0_r.
   assert (vec_inf_norm x0 = 0%Re).
-  { unfold vec_inf_norm, x0. apply bigmaxrP.
-    split.
-    + assert (0%Re = [seq Rabs ((\col__ 0%Re) i 0)
-                      | i <- enum 'I_n.+1]`_0).
-      { rewrite seq_equiv. rewrite nth_mkseq.
-        rewrite !mxE. by rewrite Rabs_R0.
-        by [].
-      } rewrite [in X in (X \in _)]H1.
-      apply (@mem_nth _ 0%Re [seq Rabs ((\col__ 0%Re) i 0)
-                      | i <- enum 'I_n.+1] 0%nat).
-      by rewrite size_map size_enum_ord.
-    + intros. rewrite seq_equiv. rewrite nth_mkseq;
-      last by rewrite size_map size_enum_ord in H1.
-      rewrite !mxE Rabs_R0. apply /RleP. apply Rle_refl.
+  { unfold vec_inf_norm, x0. apply bigmaxP_0head.
+    - by rewrite size_map size_enum_ord.
+    - intros. rewrite (@nth_map 'I_n.+1 ord0).
+      rewrite !mxE. rewrite Rabs_R0. lra.
+      by rewrite size_map in H1.
+    - intros. move /mapP in H1. destruct H1 as [i2 H1 H2].
+      rewrite H2. apply /RleP. apply Rabs_pos.
+    - apply /mapP. exists ord0. apply mem_enum.
+      rewrite mxE. rewrite Rabs_R0. auto.
   } rewrite H1. nra.
 + rewrite big_ord_recr /=. rewrite -RplusE.
   unfold x_fix.

--- a/diag_invertibility.v
+++ b/diag_invertibility.v
@@ -174,19 +174,25 @@ Lemma vec_norm_not_zero_implies {n:nat}:
   exists k, Rabs (v k ord0) = vec_inf_norm v /\
             v k ord0 <> 0%Re.
 Proof.
-intros. unfold vec_inf_norm in H.
-pose proof  bigmax_not_0_implies.
-specialize (H0 0%Re [seq Rabs (v i ord0)
-                          | i <- enum 'I_n.+1] H).
-rewrite size_map size_enum_ord in H0.
-destruct H0 as [i [Hsize H0]].
-exists (@inord n i). 
-unfold vec_inf_norm.
-rewrite seq_equiv in H0. rewrite nth_mkseq in H0; last by apply Hsize.
-destruct H0 as [H0a H0b].
-split.
-+ rewrite seq_equiv. apply H0a.
-+ by apply R0_no_Rabs.
+  intros. rewrite /vec_inf_norm in H.
+  assert (forall x, x \in [seq Rabs (v i ord0) | i <- enum 'I_n.+1] -> 0 <= x).
+  { intros. move /mapP in H0. destruct H0 as [i0 H1 H2]. rewrite H2. 
+    apply /RleP. apply Rabs_pos. }
+  pose proof (@bigmax_not_0_implies_0head 
+    [seq Rabs (v i ord0) | i <- enum 'I_n.+1] H0 H).
+  destruct H1 as [i [Hsize [H1 H2]]].
+  rewrite size_map in Hsize.
+  exists (inord i). split.
+  + rewrite /vec_inf_norm.
+    rewrite -H1 (@nth_map _ ord0); auto. f_equal. f_equal.
+    pose proof (@nth_ord_enum n.+1 ord0 (inord i)).
+    rewrite -H3. f_equal. rewrite inordK; auto. by rewrite size_enum_ord in Hsize.
+  + assert (seq.nth 0%Re [seq Rabs (v i0 ord0) | i0 <- enum 'I_n.+1] i
+      = Rabs (v (inord i) ord0)).
+    { rewrite (@nth_map _ ord0); auto. f_equal. f_equal.
+      rewrite -(@nth_ord_enum n.+1 ord0 (inord i)). f_equal. 
+      rewrite inordK; auto. by rewrite size_enum_ord in Hsize. }
+    rewrite H3 in H2. apply R0_no_Rabs. apply H2.
 Qed.
 
 Lemma Rabs_sub: 
@@ -313,10 +319,13 @@ assert (vec_inf_norm v_c = 0%Re \/ vec_inf_norm v_c <> 0%Re).
       | i0 <- enum 'I_n.+1]`_i.
     * rewrite seq_equiv. rewrite nth_mkseq; last by apply ltn_ord.
       rewrite inord_val. apply Rle_refl.
-    * apply /RleP. 
-      apply (@bigmaxr_ler _ 0%Re [seq Rabs (v_c i0 0)
-                                    | i0 <- enum 'I_n.+1] i).
-      rewrite size_map size_enum_ord. apply ltn_ord.
+    * apply bigmax_ler_0head.
+      { apply /mapP. exists i. apply mem_enum.
+        rewrite (@nth_map _ ord0).
+        f_equal. f_equal. rewrite (@nth_ord_enum n.+1 ord0 i). auto.
+        rewrite size_enum_ord. apply ltn_ord. }
+      intros.  move /mapP in H5. destruct H5 as [x0 H6 H7]. rewrite H7.
+      apply /RleP. apply Rabs_pos.
   - auto.
 Qed.
 

--- a/diag_invertibility.v
+++ b/diag_invertibility.v
@@ -83,7 +83,9 @@ destruct H.
 + rewrite Rmax_left. by left. apply H.
 Qed.
 
-Lemma bigmax_destruct (a x0:R) s:
+(* bigmaxr deprecated *)
+(* The following three lemmas are moved to lemmas.v *)
+(* Lemma bigmax_destruct (a x0:R) s:
   bigmaxr x0 (a :: s) = a \/ 
   bigmaxr x0 (a :: s) = bigmaxr x0 s.
 Proof.
@@ -97,10 +99,10 @@ assert (s = [::] \/ s != [::]).
   { by apply s_destruct. } rewrite H0.
   rewrite bigmaxr_cons. rewrite -H0.
   rewrite -RmaxE. apply max_order.
-Qed.
+Qed. *)
 
 
-Lemma bigmax_not_0_implies_aux (x0:R) s:
+(* Lemma bigmax_not_0_implies_aux (x0:R) s:
   (0 < size s)%nat ->
   (exists i, (i < size s)%nat /\
              seq.nth x0 s i = bigmaxr x0 s).
@@ -125,9 +127,9 @@ induction s.
       exists i.+1. split.
       ++ simpl. by []. 
       ++ simpl. by rewrite H0.
-Qed. 
+Qed.  *)
   
-Lemma bigmax_not_0_implies (x0:R) s:
+(* Lemma bigmax_not_0_implies (x0:R) s:
   bigmaxr x0 s <> x0 ->
   (exists i, (i < size s)%nat /\
              seq.nth x0 s i = bigmaxr x0 s /\
@@ -148,7 +150,7 @@ assert (s = [::] \/ s != [::]).
   exists i. split.
   apply Hsize. split.
   apply H2. by rewrite H2.
-Qed.
+Qed. *)
 
 Close Scope R_scope.
 

--- a/floatlib.v
+++ b/floatlib.v
@@ -57,7 +57,7 @@ Lemma matrix_by_index_rows:
 Proof.
 intros.
 unfold matrix_by_index, matrix_rows_nat.
-rewrite map_length. rewrite seq_length. auto.
+rewrite length_map. rewrite length_seq. auto.
 Qed.
 
 Local Open Scope nat.
@@ -70,7 +70,7 @@ intros.
 unfold matrix_by_index, matrix_cols_nat.
 pose (k := 0). change (seq 0 rows) with (seq k rows).
 clearbody k. revert k; induction rows; intros; constructor; auto.
-rewrite map_length, seq_length. auto.
+rewrite length_map, length_seq. auto.
 Qed.
 
 Lemma nth_map_seq:
@@ -314,7 +314,7 @@ rewrite !Zlength_correct in H. apply Nat2Z.inj in H.
 unfold dotprod in H0.
 rewrite <- fold_left_rev_right in H0.
 rewrite rev_combine in H0 by auto.
-rewrite <- (rev_length x), <- (rev_length y) in H.
+rewrite <- (length_rev x), <- (length_rev y) in H.
 assert (Forall finite (rev x) /\ Forall finite (rev y)).
 2:rewrite <- (rev_involutive x), <- (rev_involutive y);
    destruct H1; split; apply Forall_rev; auto.
@@ -351,10 +351,10 @@ Proof.
 intros.
 unfold matrix_by_index.
 apply Forall_nth; intros.
-rewrite map_length, seq_length in H1.
+rewrite length_map, length_seq in H1.
 rewrite nth_map_seq by auto.
 apply Forall_nth; intros.
-rewrite map_length, seq_length in H2.
+rewrite length_map, length_seq in H2.
 rewrite nth_map_seq by auto.
 apply H0; auto.
 Qed.
@@ -374,7 +374,7 @@ Qed.
 
 Lemma Zlength_seq: forall lo n, Zlength (seq lo n) = Z.of_nat n.
 Proof.
-intros. rewrite Zlength_correct. f_equal. apply seq_length.
+intros. rewrite Zlength_correct. f_equal. apply length_seq.
 Qed.
 #[export] Hint Rewrite Zlength_seq : sublist rep_lia.
 

--- a/fma_dot_mat_model.v
+++ b/fma_dot_mat_model.v
@@ -35,7 +35,7 @@ assert (nth i (invert_diagmatrix (diag_of_matrix A))
             (Zconst ty 1) = 
         BDIV (Zconst ty 1) (nth i (diag_of_matrix A) (Zconst ty 1))).
 { rewrite (nth_map_inrange (Zconst ty 1)); try by [].
-  by rewrite /diag_of_matrix map_length seq_length /matrix_rows_nat .
+  by rewrite /diag_of_matrix length_map length_seq /matrix_rows_nat .
 } rewrite H0.
 unfold diag_of_matrix.  rewrite nth_map_seq.
 by unfold matrix_index.
@@ -50,7 +50,7 @@ Lemma v_equiv {ty} (v: vector ty) size:
 Proof.
 intros. 
 apply nth_ext with (Zconst ty 0) (Zconst ty 0).
-+ rewrite rev_length length_veclist. by []. 
++ rewrite length_rev length_veclist. by []. 
 + intros. rewrite rev_nth length_veclist.
   assert ((size.+1 - n.+1)%coq_nat = (size.+1.-1 - n)%coq_nat).
   { by []. } rewrite H1.
@@ -79,9 +79,9 @@ Lemma A2_equiv {ty} (A: matrix ty) size i :
 Proof.
 intros.
 apply nth_ext with (Zconst ty 0) (Zconst ty 0).
-+ rewrite rev_length length_veclist. 
++ rewrite length_rev length_veclist. 
   unfold matrix_by_index. rewrite nth_map_seq.
-  - rewrite map_length. rewrite seq_length. by unfold matrix_rows_nat.
+  - rewrite length_map. rewrite length_seq. by unfold matrix_rows_nat.
   - unfold matrix_rows_nat. by rewrite H. 
 + intros.
   rewrite rev_nth length_veclist.
@@ -102,21 +102,21 @@ apply nth_ext with (Zconst ty 0) (Zconst ty 0).
                assert ( i == n :> nat = false). { by apply /eqP. }
                rewrite H3. by unfold matrix_index. 
          -- rewrite /matrix_by_index nth_map_seq in H1.
-            ** rewrite map_length seq_length /matrix_rows_nat H in H1.
+            ** rewrite length_map length_seq /matrix_rows_nat H in H1.
                by apply /ssrnat.ltP.
             ** unfold matrix_rows_nat. by rewrite H. 
          -- by apply /ssrnat.ltP.
       ++ rewrite /matrix_by_index nth_map_seq in H1.
-         -- rewrite map_length seq_length /matrix_rows_nat H in H1.
+         -- rewrite length_map length_seq /matrix_rows_nat H in H1.
             by rewrite /matrix_rows_nat H.
          -- unfold matrix_rows_nat. by rewrite H.
     * unfold matrix_rows_nat. by rewrite H.
   - rewrite /matrix_by_index nth_map_seq in H1.
-    -- rewrite map_length seq_length /matrix_rows_nat H in H1.
+    -- rewrite length_map length_seq /matrix_rows_nat H in H1.
        by apply /ssrnat.ltP.
     -- unfold matrix_rows_nat. by rewrite H.
   - rewrite /matrix_by_index nth_map_seq in H1.
-    -- by rewrite map_length seq_length /matrix_rows_nat H in H1.
+    -- by rewrite length_map length_seq /matrix_rows_nat H in H1.
     -- unfold matrix_rows_nat. by rewrite H.
 Qed.
 
@@ -187,9 +187,9 @@ Lemma iter_length {ty} n (A: matrix ty) (b: vector ty) (x: vector ty):
 Proof.
 induction n.
 + by simpl.
-+ simpl. repeat rewrite !map_length combine_length.
-  unfold matrix_vector_mult. rewrite map_length.
-  rewrite !map_length !seq_length /matrix_rows_nat /=.
++ simpl. repeat rewrite !length_map length_combine.
+  unfold matrix_vector_mult. rewrite length_map.
+  rewrite !length_map !length_seq /matrix_rows_nat /=.
   intros. rewrite H. by rewrite !Nat.min_id.
 Qed.
   
@@ -231,10 +231,10 @@ induction n.
              rewrite (nth_map_inrange (Zconst ty 0, Zconst ty 0)).
              + rewrite combine_nth. 
                - reflexivity.
-               - unfold matrix_vector_mult. rewrite map_length. 
-                 unfold remove_diag. rewrite map_length seq_length.
+               - unfold matrix_vector_mult. rewrite length_map. 
+                 unfold remove_diag. rewrite length_map length_seq.
                  by unfold matrix_rows_nat.
-             + rewrite combine_length. rewrite !map_length seq_length /matrix_rows_nat H0 Nat.min_id /=.
+             + rewrite length_combine. rewrite !length_map length_seq /matrix_rows_nat H0 Nat.min_id /=.
                 assert (length A = size.+1).
                 { rewrite /size. by rewrite prednK. } rewrite H2. 
                 apply /ssrnat.ltP. apply ltn_ord. 
@@ -250,9 +250,9 @@ induction n.
      * assert (length A = size.+1).
        { rewrite /size. by rewrite prednK. } rewrite H2. 
        apply /ssrnat.ltP. apply ltn_ord.
-     * rewrite  !map_length !seq_length combine_length !map_length !seq_length.
+     * rewrite  !length_map !length_seq length_combine !length_map !length_seq.
        by rewrite /matrix_rows_nat H0 Nat.min_id.
-  - rewrite  combine_length !map_length !seq_length combine_length !map_length !seq_length.
+  - rewrite  length_combine !length_map !length_seq length_combine !length_map !length_seq.
      rewrite /matrix_rows_nat H0 !Nat.min_id.
      assert (length A = size.+1).
      { rewrite /size. by rewrite prednK. } rewrite H2. 

--- a/fma_floating_point_model.v
+++ b/fma_floating_point_model.v
@@ -83,7 +83,7 @@ elim: v1 v2 H => [ |s v1 IHv1] v2 H.
     { simpl in H. lia. } specialize (IHv1 H0).
     simpl. rewrite -IHv1.
     assert (length (rev v1) = length (rev v2)).
-    { by rewrite !rev_length. }
+    { by rewrite !length_rev. }
     clear IHv1 H H0.
     elim: (rev v1) (rev v2) H1  => [ |a1 v3 IHv3] v4 H.
     * destruct v4.

--- a/fma_jacobi_forward_error.v
+++ b/fma_jacobi_forward_error.v
@@ -304,7 +304,6 @@ Proof.
      } specialize (H H2). apply H.
     + rewrite inordK; auto.
     + rewrite inordK; auto. } specialize (H1 H2).
-
   destruct H1 as [d [e [Heq [Hd [He H1]]]]].
   rewrite H1. rewrite !nth_vec_to_list_float.
   - rewrite !nth_vec_to_list_real.
@@ -383,46 +382,45 @@ Lemma inverse_mat_norm_bound {ty} {n:nat} (A: 'M[ftype ty]_n.+1):
   (vec_inf_norm (FT2R_mat (A1_inv_J A) - A1_diag A_real) <=
     vec_inf_norm (A1_diag A_real) * (default_rel ty) + (default_abs ty))%Re.
 Proof.
-intros.
-assert (Hneq: forall i, (FT2R (A i i) <> 0%Re)).
-{ intros. by apply BDIV_FT2R_sep_zero. }
-unfold vec_inf_norm. rewrite RmultE. rewrite mulrC.
-rewrite -bigmaxr_mulr.
-+ apply lemmas.bigmax_le; first by rewrite size_map size_enum_ord.
-  intros. rewrite seq_equiv. 
-  rewrite nth_mkseq; last by rewrite size_map size_enum_ord in H1.
-  rewrite !mxE. 
+  intros.
+  assert (Hneq: forall i, (FT2R (A i i) <> 0%Re)).
+  { intros. by apply BDIV_FT2R_sep_zero. }
+  unfold vec_inf_norm. rewrite RmultE. rewrite mulrC.
+  rewrite -!RmultE. rewrite bigmax_mulr_0head.
+  2:{ rewrite size_map size_enum_ord. auto. }
+  2:{ intros. move /mapP in H1. destruct H1 as [x0 H1 H2]. rewrite H2. apply /RleP. apply Rabs_pos. } 
+  2:{ apply /RleP. apply default_rel_ge_0. } 
+  apply bigmax_le_0head.
+  { rewrite size_map size_enum_ord. auto. }
+  2:{ intros. move /mapP in H1. destruct H1 as [x0 H1 H2]. rewrite H2. apply /RleP. apply Rabs_pos. } 
+  intros. rewrite size_map size_enum_ord in H1.
+  rewrite seq_equiv nth_mkseq; auto.
   apply Rle_trans with 
-  ([seq (default_rel ty *
-         Rabs (A1_diag A_real i0 0))%Ri
-      | i0 <- enum 'I_n.+1]`_i + (default_abs ty))%Re.
-  - rewrite seq_equiv. rewrite nth_mkseq;
-    last by rewrite size_map size_enum_ord in H1.
-    rewrite -RmultE -RminusE. rewrite !mxE.
+    ([seq (default_rel ty * Rabs (A1_diag A_real i0 0))%Ri | i0 <- enum 'I_n.+1]`_i + (default_abs ty))%Re.
+  { rewrite seq_equiv nth_mkseq; auto.
+    rewrite -!RmultE. rewrite !mxE.
     specialize (H0 (@inord n i)). specialize (H (@inord n i)).
     pose proof (@Binv_accurate _ ty (A (inord i) (inord i))) .
     specialize (H2 H H0).
     destruct H2 as [d [e [Hpr [Hdf [Hde H2]]]]].
     rewrite H2 /=. rewrite real_const_1.
-    assert ((1 / FT2R (A (inord  i) (inord i)) *
-              (1 + d) + e -
-              1 / FT2R (A (inord i) (inord i)))%Re = 
-            ((1 / FT2R (A (inord i) (inord i))) * d + e)%Re).
-    { nra. } rewrite H3.
+    assert ((1 / FT2R (A (inord  i) (inord i)) * (1 + d) + e - 1 / FT2R (A (inord i) (inord i)))%Re = 
+            ((1 / FT2R (A (inord i) (inord i))) * d + e)%Re) by nra.
+    rewrite -RminusE. rewrite H3.
     eapply Rle_trans.
     apply Rabs_triang.
     * apply Rplus_le_compat.
       ++ rewrite Rmult_comm. rewrite Rabs_mult. apply Rmult_le_compat_r.
          apply Rabs_pos. apply Hdf.
-      ++ apply Hde.
-  - apply Rplus_le_compat_r.
-    apply /RleP.
-    apply (@bigmaxr_ler _ 0%Re [seq default_rel ty *
-                                     Rabs (A1_diag A_real i0 0)
-                                   | i0 <- enum 'I_n.+1] i).
-    rewrite size_map size_enum_ord.
-    by rewrite size_map size_enum_ord in H1.
-+ apply /RleP. apply default_rel_ge_0.
+      ++ apply Hde. }
+  apply Rplus_le_compat_r. apply bigmax_ler_0head.
+  { apply /mapP. exists (Rabs (A1_diag A_real (inord i) 0)).
+    + apply /mapP. exists (inord i). apply mem_enum. reflexivity.
+    + rewrite seq_equiv nth_mkseq; auto. } 
+  intros. move /mapP in H2. destruct H2 as [x0 H2 H3]. rewrite H3.
+  apply mulr_ge0. apply /RleP. apply default_rel_ge_0.
+  move /mapP in H2. destruct H2 as [x1 H2 H4]. rewrite H4.
+  apply /RleP. apply Rabs_pos.
 Qed.
 
 
@@ -541,22 +539,6 @@ Definition rho_def  {t: type} {n:nat} (A: 'M[ftype t]_n.+1) (b: 'cV[ftype t]_n.+
                  default_abs t) *
                 matrix_inf_norm (A2_J_real A_real) + R)%Re.
 
-Definition rho_def_sparse  {t: type} {n:nat} 
-  (A: 'M[ftype t]_n.+1) (b: 'cV[ftype t]_n.+1) 
-  (r : nat) :=
-  let A_real := FT2R_mat A in
-  let b_real := FT2R_mat b in  
-  let R := (vec_inf_norm (A1_diag A_real) * matrix_inf_norm (A2_J_real A_real))%Re in
-  let delta := default_rel t in
-  ((((1 + g t r.+1) * (1 + delta) *
-                  g t r.+1 + delta * (1 + g t r.+1) +
-                  g t r.+1) * (1 + delta) + delta) * R +
-                (((1 + g t r.+1) * (1 + delta) *
-                  g t r.+1 + delta * (1 + g t r.+1) +
-                  g t r.+1) * default_abs t +
-                 default_abs t) *
-                matrix_inf_norm (A2_J_real A_real) + R)%Re.
-
 
 Definition d_mag_def {t: type} {n:nat} (A: 'M[ftype t]_n.+1) 
   (b: 'cV[ftype t]_n.+1) :=
@@ -586,34 +568,6 @@ Definition d_mag_def {t: type} {n:nat} (A: 'M[ftype t]_n.+1)
                      matrix_inf_norm (A2_J_real A_real)) *
                     vec_inf_norm (x_fix x b_real A_real))%Re.
 
-Definition d_mag_def_sparse {t: type} {n:nat} 
-  (A: 'M[ftype t]_n.+1) (b: 'cV[ftype t]_n.+1) 
-  (r : nat) :=
-  let A_real := FT2R_mat A in
-  let b_real := FT2R_mat b in  
-  let x:= mulmx (A_real^-1) b_real in
-  let R := (vec_inf_norm (A1_diag A_real) * matrix_inf_norm (A2_J_real A_real))%Re in
-  let delta := default_rel t in
-  ((g t r.+1 * (1 + delta) + delta) *
-                    ((vec_inf_norm (A1_diag A_real) *
-                      (1 + delta) + default_abs t) *
-                     vec_inf_norm b_real) +
-                    (1 + g t r.+1) * g1 t r.+1 (r.+1 - 1) *
-                    (1 + delta) *
-                    (vec_inf_norm (A1_diag A_real) *
-                     (1 + delta) + default_abs t) +
-                    g1 t r.+1 (r.+1 - 1) +
-                    (vec_inf_norm (A1_diag A_real) * delta +
-                     default_abs t) * vec_inf_norm b_real +
-                    ((((1 + g t r.+1) * (1 + delta) *
-                       g t r.+1 + delta * (1 + g t r.+1) +
-                       g t r.+1) * (1 + delta) + delta) * R +
-                     (((1 + g t r.+1) * (1 + delta) *
-                       g t r.+1 + delta * (1 + g t r.+1) +
-                       g t r.+1) * default_abs t +
-                      default_abs t) *
-                     matrix_inf_norm (A2_J_real A_real)) *
-                    vec_inf_norm (x_fix x b_real A_real))%Re.
 
 Lemma d_mag_ge_0 {t: type} {n:nat} (A: 'M[ftype t]_n.+1) 
   (b: 'cV[ftype t]_n.+1):
@@ -673,64 +627,7 @@ repeat apply Rplus_le_le_0_compat.
     * nra.
 Qed.
 
-Lemma d_mag_sparse_ge_0 {t: type} {n:nat} (A: 'M[ftype t]_n.+1) 
-  (b: 'cV[ftype t]_n.+1) (r : nat) :
-  (0 <= d_mag_def_sparse A b r)%Re.
-Proof.
-  unfold d_mag_def_sparse.
-  repeat apply Rplus_le_le_0_compat.
-  + repeat try apply Rmult_le_pos; try repeat apply Rplus_le_le_0_compat.
-    - apply Rmult_le_pos; try apply g_pos.
-      apply Rplus_le_le_0_compat; try nra; try apply default_rel_ge_0.
-    - apply default_rel_ge_0.
-    - apply Rmult_le_pos. 
-      apply /RleP. apply vec_norm_pd.
-      apply Rplus_le_le_0_compat. nra. apply default_rel_ge_0.
-    - apply default_abs_ge_0.
-    - apply /RleP. apply vec_norm_pd.
-  + repeat try apply Rmult_le_pos.
-    - apply Rplus_le_le_0_compat. nra. apply g_pos.
-    - apply pos_INR.
-    - nra.
-    - apply bpow_ge_0.
-    - apply Rplus_le_le_0_compat. nra. apply g_pos.
-    - apply Rplus_le_le_0_compat. nra. apply default_rel_ge_0. 
-    - apply Rplus_le_le_0_compat; last by apply default_abs_ge_0.
-      apply Rmult_le_pos; last by (apply Rplus_le_le_0_compat; try nra; try apply default_rel_ge_0).
-      apply /RleP. apply vec_norm_pd.
-  + apply g1_pos.
-  + apply Rmult_le_pos; last by (apply /RleP; try apply vec_norm_pd).
-    apply Rplus_le_le_0_compat; last by apply default_abs_ge_0.
-    apply Rmult_le_pos; last by apply default_rel_ge_0.
-    apply /RleP. apply vec_norm_pd.
-  + repeat apply Rmult_le_pos; last by (apply /RleP; try apply vec_norm_pd).
-    repeat apply Rplus_le_le_0_compat.
-    - repeat apply Rmult_le_pos.
-      * repeat apply Rplus_le_le_0_compat; last by apply default_rel_ge_0.
-        repeat apply Rmult_le_pos.
-        ++ apply Rplus_le_le_0_compat; last by apply g_pos.
-           apply Rplus_le_le_0_compat.
-           -- repeat apply Rmult_le_pos;last by apply g_pos.
-              apply Rplus_le_le_0_compat; try nra; try apply g_pos.
-              apply Rplus_le_le_0_compat; try nra; try apply default_rel_ge_0.
-           -- apply Rmult_le_pos; first by apply default_rel_ge_0.
-              apply Rplus_le_le_0_compat; try nra; try apply g_pos.
-        ++ apply Rplus_le_le_0_compat. nra. apply default_rel_ge_0.
-      * apply /RleP. apply vec_norm_pd.
-      * apply /RleP. apply matrix_norm_pd.
-    - repeat apply Rmult_le_pos; last by (apply /RleP; apply matrix_norm_pd).
-      repeat apply Rplus_le_le_0_compat; last by apply default_abs_ge_0.
-      repeat apply Rmult_le_pos; last by apply bpow_ge_0.
-      * apply Rplus_le_le_0_compat;last by apply g_pos.
-        apply Rplus_le_le_0_compat.
-        ++ repeat apply Rmult_le_pos;last by apply g_pos.
-           apply Rplus_le_le_0_compat; try nra; try apply g_pos.
-           apply Rplus_le_le_0_compat; try nra; try apply default_rel_ge_0.
-        ++ apply Rmult_le_pos; first by apply default_rel_ge_0.
-           apply Rplus_le_le_0_compat. nra. apply g_pos.
-      * nra.
-Qed.
-  
+
 
 Lemma x_k_bound {ty} {n:nat} 
   (A: 'M[ftype ty]_n.+1) (x0 b: 'cV[ftype ty]_n.+1) k i:
@@ -761,59 +658,19 @@ apply Rle_trans with
     * rewrite seq_equiv. rewrite nth_mkseq; 
       last by apply ltn_ord.
       rewrite mxE. rewrite inord_val. apply Rle_refl.
-    * apply /RleP.
-      apply (@bigmaxr_ler  _ 0%Re [seq Rabs
-                                   (FT2R_mat (X_m_jacobi k x0 b A) i0 0)
-                               | i0 <- enum 'I_n.+1] i).
-      rewrite size_map size_enum_ord.
-      by apply ltn_ord.
+    * apply bigmax_ler_0head.
+      { rewrite (@nth_map 'I_n.+1 ord0).
+        2:{ rewrite size_enum_ord. apply ltn_ord. }
+        rewrite nth_ord_enum. apply /mapP. exists (inord i).
+        apply mem_enum. by rewrite inord_val. }
+      intros. move /mapP in H0. destruct H0 as [x2 H1 H2].
+      rewrite H2. apply /RleP. apply Rabs_pos.
   - assert (forall x y z d: R, (x - y <= z + d)%Re -> (x <= y + z + d)%Re).
     { intros. nra. } apply H0.
     apply /RleP. apply reverse_triang_ineq.
     by apply /RleP.
 Qed.
 
-Lemma x_k_bound_sparse {ty} {n:nat} 
-  (A: 'M[ftype ty]_n.+1) (x0 b: 'cV[ftype ty]_n.+1) 
-  (r : nat) (HA : is_r_sparse_mat A r) k i:
-  let A_real := FT2R_mat A in
-  let b_real := FT2R_mat b in
-  let x:= A_real^-1 *m b_real in
-  let rho := rho_def_sparse A b r in 
-  let d_mag := d_mag_def_sparse A b r in 
-   (f_error k b x0 x A <=
-       rho ^ k * f_error 0 b x0 x A +
-       (1 - rho ^ k) / (1 - rho) * d_mag)%Re ->
-    (Rabs (FT2R (X_m_jacobi k x0 b A i ord0)) <= 
-      vec_inf_norm
-         (x_fix x (FT2R_mat b) (FT2R_mat A)) +
-       rho ^ k * f_error 0 b x0 x A +
-       (1 - rho ^ k) / (1 - rho) * d_mag)%Re.
-Proof.
-intros.
-rewrite [in X in (X <= _)%Re]/f_error in H.
-apply Rle_trans with 
-  (vec_inf_norm (FT2R_mat (X_m_jacobi k x0 b A))).
-  - unfold vec_inf_norm.
-    apply Rle_trans with 
-     [seq Rabs
-          (FT2R_mat (X_m_jacobi k x0 b A)
-             i0 0)
-          | i0 <- enum 'I_n.+1]`_i.
-    * rewrite seq_equiv. rewrite nth_mkseq; 
-      last by apply ltn_ord.
-      rewrite mxE. rewrite inord_val. apply Rle_refl.
-    * apply /RleP.
-      apply (@bigmaxr_ler  _ 0%Re [seq Rabs
-                                   (FT2R_mat (X_m_jacobi k x0 b A) i0 0)
-                               | i0 <- enum 'I_n.+1] i).
-      rewrite size_map size_enum_ord.
-      by apply ltn_ord.
-  - assert (forall x y z d: R, (x - y <= z + d)%Re -> (x <= y + z + d)%Re).
-    { intros. nra. } apply H0.
-    apply /RleP. apply reverse_triang_ineq.
-    by apply /RleP.
-Qed.
 
 Definition input_bound {t} {n:nat} 
   (A: 'M[ftype t]_n.+1) (x0 b: 'cV[ftype t]_n.+1):=
@@ -878,68 +735,6 @@ Definition input_bound {t} {n:nat}
      (bpow Zaux.radix2 (femax t) -
       default_abs t) / (1 + default_rel t))%Re.
 
-Definition input_bound_sparse {t} {n:nat} 
-  (A: 'M[ftype t]_n.+1) (x0 b: 'cV[ftype t]_n.+1) (r : nat) :=
-  let A_real := FT2R_mat A in
-  let b_real := FT2R_mat b in
-  let x:= A_real^-1 *m b_real in
-  let rho := rho_def_sparse A b r in 
-  let d_mag := d_mag_def_sparse A b r in
-  (forall i,
-    (Rabs (FT2R (A i i)) *
-     (1 * (1 + rho) *
-      (f_error 0 b x0 x A -
-       d_mag * / (1 - rho)) +
-      2 * d_mag * / (1 - rho) +
-      2 *
-      vec_inf_norm
-        (x_fix x (FT2R_mat b) (FT2R_mat A))) <
-     (sqrt (fun_bnd t r.+1) - default_abs t) /
-     (1 + default_rel t) /
-     (1 + default_rel t))%Re) /\ 
-  (vec_inf_norm
-   (x_fix x (FT2R_mat b) (FT2R_mat A)) +
-       1 *
-       f_error 0 b x0 x A +
-       1 / (1 - rho) *
-       d_mag < sqrt (fun_bnd t r.+1))%Re /\
-  (forall i j, 
-      (Rabs (FT2R (A2_J A i j )) <
-        sqrt (fun_bnd t r.+1))%Re) /\
-  (forall i,
-     (Rabs (FT2R (b i ord0)) +
-     (1 + g t r.+1) *
-     ((vec_inf_norm
-         (x_fix x (FT2R_mat b) (FT2R_mat A)) +
-       1 * f_error 0 b x0 x A +
-       1 / (1 - rho) * d_mag) *
-      (\sum_j
-          Rabs (FT2R (A2_J A i j)))) +
-     g1 t r.+1 (r.+1 - 1)%coq_nat <
-     (bpow Zaux.radix2 (femax t) -
-      default_abs t) / (1 + default_rel t))%Re) /\
-  (forall i,
-    (Rabs (FT2R (A1_inv_J A (inord i) ord0)) *
-     (Rabs (FT2R (b (inord i) ord0)) +
-      (1 + g t r.+1) *
-      ((vec_inf_norm
-          (x_fix x (FT2R_mat b) (FT2R_mat A)) +
-        1 * f_error 0 b x0 x A +
-        1 / (1 - rho) * d_mag) *
-       (\sum_j
-           Rabs (FT2R (A2_J A (inord i) j)))) +
-      g1 t r.+1 (r.+1 - 1)%coq_nat) <
-     (bpow Zaux.radix2 (femax t) -
-      default_abs t) / (1 + default_rel t) /
-     (1 + default_rel t))%Re) /\
-  (1 * (1 + rho) *
-     ((f_error 0 b x0 x A) - d_mag * / (1 - rho)) +
-     2 * d_mag * / (1 - rho) +
-     2 *
-     vec_inf_norm
-       (x_fix x (FT2R_mat b) (FT2R_mat A)) <
-     (bpow Zaux.radix2 (femax t) -
-      default_abs t) / (1 + default_rel t))%Re.
 
 
 
@@ -999,69 +794,6 @@ apply Rle_lt_trans with
 Qed.
 
 
-
-Lemma bound_1_sparse  {t: type} {n:nat}
-  (A : 'M[ftype t]_n.+1) (x0 b : 'cV[ftype t]_n.+1) (k:nat) m
-  (r : nat) (HA : is_r_sparse_mat A r):
-  let A_real := FT2R_mat A in
-  let b_real := FT2R_mat b in
-  let x:= A_real^-1 *m b_real in
-  let rho := rho_def_sparse A b r in 
-  let d_mag := d_mag_def_sparse A b r in 
-  input_bound A x0 b ->
-  (rho < 1)%Re ->
-  (0 < f_error 0 b x0 x A -
-         d_mag_def A b * / (1 - rho_def_sparse A b r))%Re ->
-  (Rabs (FT2R (A (inord m) (inord m))) *
-   (rho ^ k * (1 + rho) *
-    (f_error 0 b x0 x A -
-     d_mag * / (1 - rho)) +
-    2 * d_mag * / (1 - rho) +
-    2 *
-    vec_inf_norm
-      (x_fix x (FT2R_mat b) (FT2R_mat A))) <
-   (sqrt (fun_bnd t n.+1) - default_abs t) /
-   (1 + default_rel t) /
-   (1 + default_rel t))%Re.
-Proof.
-intros.
-unfold input_bound in H.
-destruct H as [bnd1 H]. clear H.
-apply Rle_lt_trans with 
-(Rabs (FT2R (A (inord m) (inord m))) *
-        (1 * (1 + rho_def_sparse A b r) *
-         (f_error 0 b x0
-            ((FT2R_mat A)^-1 *m 
-             FT2R_mat b) A -
-          d_mag_def A b *
-          / (1 - rho_def_sparse A b r)) +
-         2 * d_mag_def A b *
-         / (1 - rho_def_sparse A b r) +
-         2 *
-         vec_inf_norm
-           (x_fix
-              ((FT2R_mat A)^-1 *m FT2R_mat b)
-              (FT2R_mat b) (FT2R_mat A))))%Re.
-+ apply Rmult_le_compat_l. apply Rabs_pos.
-  change (_ *m _) with x.
- (* unfold d_mag.*)
-  fold rho in H1|-*.
-  set v := vec_inf_norm _.
-  replace (d_mag_def _ _) with d_mag in H1|- * by admit.
-  replace rho with (rho_def A b) in * by admit. clear rho.
-  repeat apply Rplus_le_compat_r.
-  apply Rmult_le_compat_r. apply Rlt_le. apply H1.
-  apply Rmult_le_compat_r.
-  apply Rplus_le_le_0_compat. nra. 
- by apply rho_ge_0.
-  assert ( 1%Re = (1 ^ k)%Re) by (rewrite pow1; nra).
-  rewrite H. apply pow_incr.
-  split. by apply rho_ge_0.
-  apply Rlt_le. apply H0.
-+ fold rho.
-  replace rho with (rho_def A b) by admit. 
- apply bnd1.
-Admitted.
   
 
 
@@ -1117,58 +849,7 @@ apply Rle_lt_trans with
 + apply bnd2.
 Qed.
 
-Lemma bound_2_sparse {ty} {n:nat} 
-  (A: 'M[ftype ty]_n.+1) (x0 b: 'cV[ftype ty]_n.+1) k
-  (r : nat) (HA : is_r_sparse_mat A r):
-  let A_real := FT2R_mat A in
-  let b_real := FT2R_mat b in
-  let x:= A_real^-1 *m b_real in
-  let rho := rho_def_sparse A b r in 
-  let d_mag := d_mag_def_sparse A b r in 
-  input_bound_sparse A x0 b r ->
-  (rho < 1)%Re ->
-  (vec_inf_norm
-   (x_fix x (FT2R_mat b) (FT2R_mat A)) +
-       rho ^ k *
-       f_error 0 b x0 x A +
-       (1 - rho ^ k) / (1 - rho) *
-       d_mag < sqrt (fun_bnd ty r.+1))%Re.
-Proof. 
-intros.
-unfold input_bound in H.
-destruct H as [_ [bnd2 H]]. clear H.
-apply Rle_lt_trans with
-(vec_inf_norm
-          (x_fix
-             ((FT2R_mat A)^-1 *m 
-              FT2R_mat b)
-             (FT2R_mat b)
-             (FT2R_mat A)) +
-        1 * f_error 0 b x0
-          ((FT2R_mat A)^-1 *m 
-           FT2R_mat b) A +
-        1 / (1 - rho_def_sparse A b r) * d_mag_def_sparse A b r)%Re.
-+ unfold x. unfold A_real, b_real. rewrite Rplus_assoc.
-  rewrite Rplus_assoc.
-  apply Rplus_le_compat_l. unfold rho, d_mag.
-  apply Rplus_le_compat.
-  - apply Rmult_le_compat_r.
-    * unfold f_error. apply /RleP.
-      apply vec_norm_pd.
-    * assert ( 1%Re = (1 ^ k)%Re) by (rewrite pow1; nra).
-      rewrite H. apply pow_incr.
-      split. by apply rho_sparse_ge_0.
-      apply Rlt_le. apply H0.
-  - apply Rmult_le_compat_r.
-    apply d_mag_sparse_ge_0. apply Rmult_le_compat_r.
-    apply Rlt_le. apply Rinv_0_lt_compat.
-    apply Rlt_Rminus. apply H0.
-    apply Rcomplements.Rle_minus_l.
-    assert (forall a b:R, (0 <= b)%Re -> (a <= a + b)%Re).
-    { intros. nra. } apply H.
-    apply pow_le. by apply rho_sparse_ge_0.
-+ apply bnd2.
-Qed.
+
 
 
 
@@ -1185,17 +866,7 @@ apply bnd3.
 Qed.
 
 
-Lemma bound_3_sparse {ty} {n:nat} 
-  (A: 'M[ftype ty]_n.+1) (x0 b: 'cV[ftype ty]_n.+1) (r : nat):
-  input_bound_sparse A x0 b r ->
-  forall i j, 
-  (Rabs (FT2R (A2_J A i j )) <
-    sqrt (fun_bnd ty r.+1))%Re.
-Proof.
-intros. unfold input_bound_sparse in H.
-destruct H as [_ [_ [bnd3 H]]]. clear H.
-apply bnd3. 
-Qed.
+
 
 
 
@@ -1358,21 +1029,6 @@ Definition forward_error_cond {ty} {n:nat}
 
 
 
-Definition forward_error_cond_sparse {ty} {n:nat} 
-  (A: 'M[ftype ty]_n.+1) (x0 b: 'cV[ftype ty]_n.+1) (r : nat) :=
-  let rho := rho_def_sparse A b r in
-  let d_mag := d_mag_def_sparse A b r in
-   let A_real := FT2R_mat A in
-  (forall i, finite (A i i)) /\
-  (rho < 1)%Re /\
-  A_real \in unitmx /\
-  (forall i : 'I_n.+1, finite (BDIV (Zconst ty 1) (A i i))) /\
-  (forall i : 'I_n.+1, finite (x0 i ord0)) /\
-  (forall i, finite  (A1_inv_J A i ord0)) /\
-  (forall i j, finite (A2_J A i j)) /\ 
-  (forall i, finite (b i ord0)) /\
-  @size_constraint ty n /\
-  input_bound_sparse A x0 b r.
 
 (** State the forward error theorem **)
 Theorem jacobi_forward_error_bound_aux {ty} {n:nat} 
@@ -1440,7 +1096,6 @@ induction k.
                              ord0) in
                dotprod_r l1 l2)).
     { pose proof (@finite_fma_from_bounded _ ty).
-      (* Need a sparse version of this shit *)
 
       specialize (H2 (vec_to_list_float n.+1
                          (\row_j A2_J A (inord i) j)^T)
@@ -1467,8 +1122,8 @@ induction k.
         assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat) by lia.
         rewrite H5 in H52. rewrite nth_vec_to_list_float  in H52.
         - rewrite mxE in H52. rewrite mxE in H52. rewrite -H52. apply HfA2.
-        - rewrite rev_length length_veclist in H51. by apply /ssrnat.ltP. 
-        - rewrite rev_length in H51. apply H51.
+        - rewrite length_rev length_veclist in H51. by apply /ssrnat.ltP. 
+        - rewrite length_rev in H51. apply H51.
       + destruct x1. simpl. apply in_combine_r in H4.
         apply in_rev in H4.
         pose proof (@In_nth _ (rev
@@ -1479,8 +1134,8 @@ induction k.
         assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat) by lia.
         rewrite H5 in H52. rewrite nth_vec_to_list_float  in H52.
         - rewrite mxE in H52. rewrite -H52. apply IHk.
-        - rewrite rev_length length_veclist in H51. by apply /ssrnat.ltP. 
-        - rewrite rev_length in H51. apply H51.
+        - rewrite length_rev length_veclist in H51. by apply /ssrnat.ltP. 
+        - rewrite length_rev in H51. apply H51.
       + destruct x1. simpl. apply in_combine_l in H4.
         apply in_rev in H4.
         pose proof (@In_nth _ (rev (vec_to_list_float n.+1
@@ -1491,8 +1146,8 @@ induction k.
         rewrite H5 in H52. rewrite nth_vec_to_list_float  in H52.
         - rewrite mxE in H52. rewrite mxE in H52. rewrite -H52. 
           by apply bound_3 with x0 b.
-        - rewrite rev_length length_veclist in H51. by apply /ssrnat.ltP. 
-        - rewrite rev_length in H51. apply H51.
+        - rewrite length_rev length_veclist in H51. by apply /ssrnat.ltP. 
+        - rewrite length_rev in H51. apply H51.
       + destruct x1. simpl. apply in_combine_r in H4.
         apply in_rev in H4.
         pose proof (@In_nth _ (rev
@@ -1507,8 +1162,8 @@ induction k.
           apply (x_k_bound (@inord n m)) in IHk2.
           eapply Rle_lt_trans.
           apply IHk2. by apply bound_2.
-        - rewrite rev_length length_veclist in H51. by apply /ssrnat.ltP. 
-        - rewrite rev_length in H51. apply H51.
+        - rewrite length_rev length_veclist in H51. by apply /ssrnat.ltP. 
+        - rewrite length_rev in H51. apply H51.
     }
     assert (finite 
             (BMINUS (b (inord i) ord0)
@@ -1993,13 +1648,13 @@ induction k.
                                  rewrite inord_val in Hfin. repeat split; try apply Hfin.
                                  apply BMULT_finite_e in Hfin; try apply Hfin.
                                  apply BMULT_finite_e in Hfin; try apply Hfin.
-                                 by rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
-                                 by rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
-                                 rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
+                                 by rewrite length_rev combine_length !length_veclist Nat.min_id in Hlength.
+                                 by rewrite length_rev combine_length !length_veclist Nat.min_id in Hlength.
+                                 rewrite length_rev combine_length !length_veclist Nat.min_id in Hlength.
                                  by apply /ssrnat.ltP.
-                                 rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
+                                 rewrite length_rev combine_length !length_veclist Nat.min_id in Hlength.
                                  by apply /ssrnat.ltP. by rewrite !length_veclist.
-                           ++++ by rewrite rev_length in Hlength.
+                           ++++ by rewrite length_rev in Hlength.
                         *** apply Rplus_le_compat_r.
                             apply Rmult_le_compat_r.
                             apply g_pos.
@@ -2036,13 +1691,13 @@ induction k.
                                    apply BMULT_finite_e in Hfin. destruct Hfin as [Hfin1 Hfin2].
                                    rewrite mxE in Hfin2. apply Bminus_bplus_opp_implies  in Hfin2.
                                    try apply Hfin2.
-                                   by rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
-                                   by rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
-                                   rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
+                                   by rewrite length_rev combine_length !length_veclist Nat.min_id in Hlength.
+                                   by rewrite length_rev combine_length !length_veclist Nat.min_id in Hlength.
+                                   rewrite length_rev combine_length !length_veclist Nat.min_id in Hlength.
                                    by apply /ssrnat.ltP.
-                                   rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
+                                   rewrite length_rev combine_length !length_veclist Nat.min_id in Hlength.
                                    by apply /ssrnat.ltP. by rewrite !length_veclist.
-                             ++++ by rewrite rev_length in Hlength.
+                             ++++ by rewrite length_rev in Hlength.
                             } apply reverse_triang_ineq in H4.
                             apply Rle_trans with 
                             ((vec_inf_norm (FT2R_mat b) +
@@ -2226,13 +1881,13 @@ induction k.
                                    apply BMULT_finite_e in Hfin. destruct Hfin as [Hfin1 Hfin2].
                                    rewrite mxE in Hfin2. apply Bminus_bplus_opp_implies  in Hfin2.
                                    try apply Hfin2.
-                                   by rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
-                                   by rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
-                                   rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
+                                   by rewrite length_rev combine_length !length_veclist Nat.min_id in Hlength.
+                                   by rewrite length_rev combine_length !length_veclist Nat.min_id in Hlength.
+                                   rewrite length_rev combine_length !length_veclist Nat.min_id in Hlength.
                                    by apply /ssrnat.ltP.
-                                   rewrite rev_length combine_length !length_veclist Nat.min_id in Hlength.
+                                   rewrite length_rev combine_length !length_veclist Nat.min_id in Hlength.
                                    by apply /ssrnat.ltP. by rewrite !length_veclist.
-                             ---- by rewrite rev_length in Hlength.
+                             ---- by rewrite length_rev in Hlength.
                ++++ assert (A2_J_real (FT2R_mat A) = FT2R_mat (A2_J A)).
                     { apply matrixP. unfold eqrel. intros. rewrite !mxE.
                        by case: (x1 == y :> nat).
@@ -2764,472 +2419,6 @@ induction k.
 Qed.
 
 
-Theorem jacobi_forward_error_bound_sparse_aux {ty} {n : nat}
-  (A: 'M[ftype ty]_n.+1) (b: 'cV[ftype ty]_n.+1)
-  (r : nat) (HA : is_r_sparse_mat A r):
-  let A_real := FT2R_mat A in 
-  let b_real := FT2R_mat b in 
-  let x := A_real^-1 *m b_real in 
-  let R := (vec_inf_norm (A1_diag A_real) * matrix_inf_norm (A2_J_real A_real))%Re in
-   let delta := default_rel ty in
-   let rho := ((((1 + g ty r.+1) * (1 + delta) *
-                  g ty r.+1 + delta * (1 + g ty r.+1) +
-                  g ty r.+1) * (1 + delta) + delta) * R +
-                (((1 + g ty r.+1) * (1 + delta) *
-                  g ty r.+1 + delta * (1 + g ty r.+1) +
-                  g ty r.+1) * default_abs ty +
-                 default_abs ty) *
-                matrix_inf_norm (A2_J_real A_real) + R)%Re in
-   let d_mag := ((g ty r.+1 * (1 + delta) + delta) *
-                    ((vec_inf_norm (A1_diag A_real) *
-                      (1 + delta) + default_abs ty) *
-                     vec_inf_norm b_real) +
-                    (1 + g ty r.+1) * g1 ty r.+1 (r.+1 - 1) *
-                    (1 + delta) *
-                    (vec_inf_norm (A1_diag A_real) *
-                     (1 + delta) + default_abs ty) +
-                    g1 ty r.+1 (r.+1 - 1) +
-                    (vec_inf_norm (A1_diag A_real) * delta +
-                     default_abs ty) * vec_inf_norm b_real +
-                    ((((1 + g ty r.+1) * (1 + delta) *
-                       g ty r.+1 + delta * (1 + g ty r.+1) +
-                       g ty r.+1) * (1 + delta) + delta) * R +
-                     (((1 + g ty r.+1) * (1 + delta) *
-                       g ty r.+1 + delta * (1 + g ty r.+1) +
-                       g ty r.+1) * default_abs ty +
-                      default_abs ty) *
-                     matrix_inf_norm (A2_J_real A_real)) *
-                    vec_inf_norm (x_fix x b_real A_real))%Re in
-  forall x0: 'cV[ftype ty]_n.+1,
-  forward_error_cond_sparse A x0 b r ->
-  (forall k:nat, 
-   (forall i, finite (X_m_jacobi k x0 b A i ord0)) /\
-   (f_error k b x0 x A <= rho^k * (f_error 0 b x0 x A) + ((1 - rho^k) / (1 - rho))* d_mag)%Re).
-Proof.
-  intros ? ? ? ? ? ? ? ? Hcond.
-  unfold forward_error_cond_sparse in Hcond.
-  destruct Hcond as [HAf [H [H0 [Hdivf [Hx0 [Ha1_inv [HfA2 [Hb [size_cons Hinp]]]]]]]]].
-  assert (forall i : 'I_n.+1, FT2R (A i i) <> 0%Re).
-  { intros. by apply BDIV_FT2R_sep_zero. }
-  induction k.
-  { split; simpl; try nra. intros. apply Hx0. }
-  assert (Hfin: (forall i : 'I_n.+1, finite (X_m_jacobi k.+1 x0 b A i ord0))).
-  { intros. simpl.
-    unfold jacobi_iter.
-    rewrite mxE.
-    rewrite nth_vec_to_list_float; last by apply ltn_ord.
-    assert (finite 
-              (let l1 :=
-                 vec_to_list_float n.+1
-                   (\row_j A2_J A (inord i) j)^T in
-               let l2 :=
-                 vec_to_list_float n.+1
-                   (\col_j X_m_jacobi k x0 b A j
-                             ord0) in
-               dotprod_r l1 l2)).
-    { pose proof (@finite_fma_from_bounded _ ty).
-      specialize (H2 (vec_to_list_float n.+1
-                         (\row_j A2_J A (inord i) j)^T)
-                      ( vec_to_list_float n.+1
-                          (\col_j X_m_jacobi k x0 b A j ord0))).
-      rewrite combine_length !length_veclist Nat.min_id in H2.
-      specialize (H2 (dotprod_r 
-                            (vec_to_list_float n.+1
-                                (\row_j A2_J A (inord i) j)^T)
-                            (vec_to_list_float n.+1
-                                 (\col_j X_m_jacobi k x0 b A j  ord0)))).
-      specialize (H2 (@fma_dot_prod_rel_holds _ _ _ n.+1 i (A2_J A) 
-                          (\col_j X_m_jacobi k x0 b A j ord0))).
-
-      (* modifications start here! *)
-      assert ((g1 ty (n.+2 +1)%coq_nat n.+2 <= fmax ty)%Re).
-      { by apply g1_constraint_Sn. } specialize (H2 H3).
-      apply H2. intros.
-      repeat split.
-      + destruct x1. simpl. apply in_combine_l in H4.
-        apply in_rev in H4.
-        pose proof (@In_nth _ (rev (vec_to_list_float n.+1
-                                 (\row_j A2_J A (inord i) j)^T)) f (Zconst ty 0) H4).
-        destruct H5 as [m [H51 H52]]. rewrite rev_nth in H52.
-        rewrite length_veclist in H52.
-        assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat) by lia.
-        rewrite H5 in H52. rewrite nth_vec_to_list_float  in H52.
-        - rewrite mxE in H52. rewrite mxE in H52. rewrite -H52. apply HfA2.
-        - rewrite rev_length length_veclist in H51. by apply /ssrnat.ltP. 
-        - rewrite rev_length in H51. apply H51.
-      + destruct x1. simpl. apply in_combine_r in H4.
-        apply in_rev in H4.
-        pose proof (@In_nth _ (rev
-                                (vec_to_list_float n.+1
-                                   (\col_j X_m_jacobi k x0 b A j ord0))) f0 (Zconst ty 0) H4).
-        destruct H5 as [m [H51 H52]]. rewrite rev_nth in H52.
-        rewrite length_veclist in H52.
-        assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat) by lia.
-        rewrite H5 in H52. rewrite nth_vec_to_list_float  in H52.
-        - rewrite mxE in H52. rewrite -H52. apply IHk.
-        - rewrite rev_length length_veclist in H51. by apply /ssrnat.ltP. 
-        - rewrite rev_length in H51. apply H51.
-      + destruct x1. simpl. apply in_combine_l in H4.
-        apply in_rev in H4.
-        pose proof (@In_nth _ (rev (vec_to_list_float n.+1
-                                 (\row_j A2_J A (inord i) j)^T)) f (Zconst ty 0) H4).
-        destruct H5 as [m [H51 H52]]. rewrite rev_nth in H52.
-        rewrite length_veclist in H52.
-        assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat) by lia.
-        rewrite H5 in H52. rewrite nth_vec_to_list_float  in H52.
-        - rewrite mxE in H52. rewrite mxE in H52. rewrite -H52. 
-          apply bound_3_sparse with x0 b.
-          admit.
-        - rewrite rev_length length_veclist in H51. by apply /ssrnat.ltP. 
-        - rewrite rev_length in H51. apply H51.
-      + destruct x1. simpl. apply in_combine_r in H4.
-        apply in_rev in H4.
-        pose proof (@In_nth _ (rev
-                                (vec_to_list_float n.+1
-                                   (\col_j X_m_jacobi k x0 b A j ord0))) f0 (Zconst ty 0) H4).
-        destruct H5 as [m [H51 H52]]. rewrite rev_nth in H52.
-        rewrite length_veclist in H52.
-        assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat) by lia.
-        rewrite H5 in H52. rewrite nth_vec_to_list_float  in H52.
-        - rewrite mxE in H52. rewrite -H52.
-          destruct IHk as [IHk1 IHk2].
-          apply (x_k_bound_sparse HA (@inord n m)) in IHk2.
-          eapply Rle_lt_trans.
-          apply IHk2. admit. (*by apply bound_2_sparse.*)
-        - rewrite rev_length length_veclist in H51. by apply /ssrnat.ltP. 
-        - rewrite rev_length in H51. apply H51.
-    }
-    assert (finite 
-            (BMINUS (b (inord i) ord0)
-               ((A2_J A *f X_m_jacobi k x0 b A)
-                  (inord i) ord0))).
-    { apply Bplus_bminus_opp_implies.
-      apply BPLUS_no_overflow_is_finite.
-        + apply Hb.
-        + rewrite finite_BOPP. rewrite mxE. apply H2.
-        + unfold Bplus_no_overflow. 
-          pose proof (@generic_round_property ty).
-          specialize (H3 (FT2R (b (inord i) ord0) +
-                             FT2R
-                               (BOPP
-                                  ((A2_J A *f
-                                    X_m_jacobi k x0 b A)
-                                     (inord i) ord0)))%Re).
-          destruct H3 as [d1 [e1 [Hde1 [Hd1 [He1 H3]]]]].
-          rewrite H3.
-          eapply Rle_lt_trans. apply Rabs_triang.
-          eapply Rle_lt_trans. apply Rplus_le_compat_l.
-          apply He1. apply Rcomplements.Rlt_minus_r.
-          rewrite Rabs_mult.
-          eapply Rle_lt_trans.
-          apply Rmult_le_compat_l. apply Rabs_pos.
-          eapply Rle_trans. apply Rabs_triang.
-          rewrite Rabs_R1. apply Rplus_le_compat_l. apply Hd1.
-          apply Rcomplements.Rlt_div_r.
-          apply Rplus_lt_le_0_compat; try nra; try apply default_rel_ge_0.
-          eapply Rle_lt_trans. apply Rabs_triang.
-          rewrite [in X in (_ + X < _)%Re]/FT2R B2R_Bopp Rabs_Ropp.
-          fold (@FT2R ty). rewrite mxE.
-          pose proof (@fma_dotprod_forward_error _ ty).
-          specialize (H4 (vec_to_list_float n.+1
-                                  (\row_j A2_J A (inord i) j)^T)
-                         (vec_to_list_float n.+1
-                            (\col_j X_m_jacobi k x0 b A j  ord0))).
-          rewrite !length_veclist in H4.
-          assert (n.+1 = n.+1). { lia. } specialize (H4 H5). 
-          clear H5.
-          specialize (H4 (dotprod_r 
-                            (vec_to_list_float n.+1
-                                (\row_j A2_J A (inord i) j)^T)
-                            (vec_to_list_float n.+1
-                                 (\col_j X_m_jacobi k x0 b A j  ord0)))).
-          specialize (H4 
-                     (\sum_j ( (FT2R (A2_J A (inord i) j)) * 
-                               (FT2R (X_m_jacobi k x0 b A j ord0)))%Re)).
-          specialize (H4
-                     (\sum_j (Rabs (FT2R (A2_J A (inord i) j)) * 
-                              Rabs (FT2R (X_m_jacobi k x0 b A j ord0)))%Re)).
-          specialize (H4 (@fma_dot_prod_rel_holds _ _ _ n.+1 i (A2_J A) 
-                          (\col_j X_m_jacobi k x0 b A j ord0))).
-          assert (\sum_j
-                     (FT2R
-                        (A2_J A (inord i) j) *
-                      FT2R
-                        (X_m_jacobi k x0 b
-                           A j ord0))%Re = 
-                  \sum_(j < n.+1)
-                          FT2R_mat (A2_J A) (inord i) (@widen_ord n.+1 n.+1 (leqnn n.+1) j) * 
-                          FT2R_mat (\col_j X_m_jacobi k x0 b A j ord0) (@widen_ord n.+1 n.+1 (leqnn n.+1) j) ord0).
-          { apply eq_big. intros. by []. intros.
-            assert ((widen_ord (m:=n.+1) (leqnn n.+1) i0) = i0).
-            { unfold widen_ord. 
-              apply val_inj. by simpl. 
-            } rewrite H6. by rewrite !mxE.
-          } rewrite H5 in H4.
-          specialize (H4 (@R_dot_prod_rel_holds _ _  n.+1 i (leqnn n.+1) (A2_J A)
-                        (\col_j X_m_jacobi k x0 b A j ord0))). 
-          assert (\sum_j
-                     (Rabs
-                        (FT2R
-                           (A2_J A 
-                              (inord i) j)) *
-                      Rabs
-                        (FT2R
-                           (X_m_jacobi k
-                              x0 b A j ord0))) =  
-                  sum_fold
-                    (map (uncurry Rmult)
-                       (map Rabsp
-                          (map FR2
-                             (combine
-                                (vec_to_list_float n.+1
-                                   (\row_j (A2_J A) (inord i) j)^T)
-                                (vec_to_list_float n.+1 
-                                  (\col_j X_m_jacobi k x0 b A j ord0))))))).
-          { rewrite -sum_fold_mathcomp_equiv.
-            apply eq_big. by []. intros.
-            assert ((widen_ord (m:=n.+1) (leqnn n.+1) i0) = i0).
-            { unfold widen_ord. 
-              apply val_inj. by simpl. 
-            } rewrite H7. by rewrite !mxE.
-          } rewrite H6 in H4.
-          specialize (H4 (R_dot_prod_rel_abs_holds    n.+1 i (A2_J A)
-                        (\col_j X_m_jacobi k x0 b A j ord0))).
-          rewrite -H6 in H4. rewrite -H5 in H4. clear H5 H6.
-          specialize (H4 H2). 
-          eapply Rle_lt_trans. apply Rplus_le_compat_l. 
-          apply Rle_trans with 
-          ((1 + g ty n.+1) * 
-            Rabs  (\sum_j
-                      Rabs (FT2R (A2_J A (inord i) j)) *
-                      Rabs (FT2R (X_m_jacobi k x0 b A j ord0))) + 
-            g1 ty n.+1 (n.+1 - 1)%coq_nat)%Re.
-          * apply Rle_trans with 
-            (Rabs ( \sum_j
-                      (FT2R (A2_J A (inord i) j) *
-                       FT2R(X_m_jacobi k x0 b A j ord0)))  +
-              (g ty n.+1 *
-                  Rabs
-                    (\sum_j
-                        Rabs
-                          (FT2R (A2_J A (inord i) j)) *
-                        Rabs
-                          (FT2R
-                             (X_m_jacobi k x0 b A j
-                                ord0))) +
-                  g1 ty n.+1 (n.+1 - 1)%coq_nat))%Re.
-            rewrite Rplus_comm.
-            apply Rcomplements.Rle_minus_l.
-            eapply Rle_trans. apply Rabs_triang_inv.
-            apply H4. rewrite -Rplus_assoc. apply Rplus_le_compat_r.
-            rewrite Rmult_plus_distr_r. apply Rplus_le_compat_r.
-            rewrite Rmult_1_l. rewrite Rabs_sum_in.
-            rewrite sum_abs_eq ; last by (intros; apply Rabs_pos).
-            apply /RleP. apply Rabs_ineq.
-          * apply Rle_refl.
-          * rewrite Rabs_sum_in. rewrite sum_abs_eq; last by (intros; apply Rabs_pos).
-            eapply Rle_lt_trans. rewrite -Rplus_assoc. apply Rplus_le_compat_r.
-            apply Rplus_le_compat_l.
-            apply Rmult_le_compat_l.
-            apply Rplus_le_le_0_compat; try nra; try apply g_pos.
-            apply Rle_trans with 
-            ((vec_inf_norm
-                 (x_fix x (FT2R_mat b) (FT2R_mat A)) +
-                     rho ^ k * f_error 0 b x0 x A +
-                     (1 - rho ^ k) / (1 - rho) * d_mag) * 
-              \sum_j (Rabs ( FT2R (A2_J A (inord i) j))))%Re.
-            ++ apply /RleP. rewrite RmultE.
-               rewrite big_distrr /=.
-               apply big_sum_ge_ex_abstract.
-               intros. rewrite -RmultE.
-               rewrite Rabs_mult. rewrite Rmult_comm.
-               apply Rmult_le_compat_r. apply Rabs_pos.
-               admit. (* apply x_k_bound. apply IHk. *)
-            ++ apply Rle_refl.
-            ++ admit. (* by apply bound_4. *)
-    }
-    apply BMULT_no_overflow_is_finite.
-    + apply Ha1_inv.
-    + rewrite nth_vec_to_list_float; last by apply ltn_ord.
-      rewrite mxE. apply H3.
-    + rewrite nth_vec_to_list_float; last by apply ltn_ord.
-      unfold Bmult_no_overflow.
-      unfold rounded.
-      pose proof (@generic_round_property ty 
-                  (FT2R (A1_inv_J A (inord i) ord0) *
-                     FT2R
-                       ((b -f
-                         A2_J A *f X_m_jacobi k x0 b A)
-                          (inord i) ord0))).
-      destruct H4 as [d [e [Hde [Hd [He H4]]]]].
-      rewrite H4. 
-      eapply Rle_lt_trans.
-      apply Rabs_triang. eapply Rle_lt_trans.
-      apply Rplus_le_compat_l. apply He.
-      apply Rcomplements.Rlt_minus_r. rewrite Rabs_mult.
-      eapply Rle_lt_trans. apply Rmult_le_compat_l. apply Rabs_pos.
-      apply Rle_trans with (Rabs 1 + Rabs d)%Re.
-      apply Rabs_triang. rewrite Rabs_R1.
-      apply Rplus_le_compat_l. apply Hd. 
-      apply Rcomplements.Rlt_div_r.
-      apply Rplus_lt_le_0_compat; try nra; try apply default_rel_ge_0.
-      rewrite Rabs_mult. rewrite [in X in (_ * X < _)%Re]mxE. 
-      rewrite Bminus_bplus_opp_equiv.
-      pose proof (@BPLUS_accurate' _ ty).
-      specialize (H5 (b (inord i) ord0) (BOPP 
-            ((A2_J A *f X_m_jacobi k x0 b A)
-                          (inord i) ord0))).
-      assert (finite
-               (BPLUS (b (inord i) ord0)
-                  (BOPP
-                     ((A2_J A *f
-                       X_m_jacobi k x0 b A)
-                        (inord i) ord0)))).
-      { by apply Bminus_bplus_opp_implies . }
-      specialize (H5 H6).
-      destruct H5 as [d1 [Hd1 H5]].
-      rewrite H5.
-      - rewrite Rabs_mult. eapply Rle_lt_trans.
-        apply Rmult_le_compat_l. apply Rabs_pos.
-        apply Rmult_le_compat_l. apply Rabs_pos.
-        apply Rle_trans with (Rabs 1 + Rabs d1)%Re.
-        apply Rabs_triang. rewrite Rabs_R1. apply Rplus_le_compat_l.
-        apply Hd1. rewrite -Rmult_assoc.
-        apply Rcomplements.Rlt_div_r.
-        apply Rplus_lt_le_0_compat; try nra; try apply default_rel_ge_0.
-        eapply Rle_lt_trans. apply Rmult_le_compat_l.
-        apply Rabs_pos. apply Rabs_triang.
-        rewrite [in X in (_ * (_ + X) < _)%Re]/FT2R B2R_Bopp.
-        rewrite Rabs_Ropp. fold (@FT2R ty).
-        rewrite [in X in (_ * (_ + X) < _)%Re]mxE.
-        pose proof (@fma_dotprod_forward_error _ ty).
-        specialize (H7 (vec_to_list_float n.+1
-                                (\row_j A2_J A (inord i) j)^T)
-                       (vec_to_list_float n.+1
-                          (\col_j X_m_jacobi k x0 b A j  ord0))).
-        rewrite !length_veclist in H7.
-        assert (n.+1 = n.+1). { lia. } specialize (H7 H8). 
-        clear H8.
-        specialize (H7 (dotprod_r 
-                          (vec_to_list_float n.+1
-                              (\row_j A2_J A (inord i) j)^T)
-                          (vec_to_list_float n.+1
-                               (\col_j X_m_jacobi k x0 b A j  ord0)))).
-       specialize (H7 
-                   (\sum_j ( (FT2R (A2_J A (inord i) j)) * 
-                             (FT2R (X_m_jacobi k x0 b A j ord0)))%Re)).
-      specialize (H7 
-                   (\sum_j (Rabs (FT2R (A2_J A (inord i) j)) * 
-                            Rabs (FT2R (X_m_jacobi k x0 b A j ord0)))%Re)).
-      specialize (H7 (@fma_dot_prod_rel_holds _ _ _ n.+1 i (A2_J A) 
-                        (\col_j X_m_jacobi k x0 b A j ord0))).
-      assert (\sum_j
-                 (FT2R
-                    (A2_J A (inord i) j) *
-                  FT2R
-                    (X_m_jacobi k x0 b
-                       A j ord0))%Re = 
-              \sum_(j < n.+1)
-                      FT2R_mat (A2_J A) (inord i) (@widen_ord n.+1 n.+1 (leqnn n.+1) j) * 
-                      FT2R_mat (\col_j X_m_jacobi k x0 b A j ord0) (@widen_ord n.+1 n.+1 (leqnn n.+1) j) ord0).
-      { apply eq_big. intros. by []. intros.
-        assert ((widen_ord (m:=n.+1) (leqnn n.+1) i0) = i0).
-        { unfold widen_ord. 
-          apply val_inj. by simpl. 
-        } rewrite H9. by rewrite !mxE.
-      } rewrite H8 in H7.
-      specialize (H7 (@R_dot_prod_rel_holds _ _  n.+1 i (leqnn n.+1) (A2_J A)
-                    (\col_j X_m_jacobi k x0 b A j ord0))). 
-      assert (\sum_j
-                 (Rabs
-                    (FT2R
-                       (A2_J A 
-                          (inord i) j)) *
-                  Rabs
-                    (FT2R
-                       (X_m_jacobi k
-                          x0 b A j ord0))) =  
-              sum_fold
-                (map (uncurry Rmult)
-                   (map Rabsp
-                      (map FR2
-                         (combine
-                            (vec_to_list_float n.+1
-                               (\row_j (A2_J A) (inord i) j)^T)
-                            (vec_to_list_float n.+1 
-                              (\col_j X_m_jacobi k x0 b A j ord0))))))).
-      { rewrite -sum_fold_mathcomp_equiv.
-        apply eq_big. by []. intros.
-        assert ((widen_ord (m:=n.+1) (leqnn n.+1) i0) = i0).
-        { unfold widen_ord. 
-          apply val_inj. by simpl. 
-        } rewrite H10. by rewrite !mxE.
-      } rewrite H9 in H7.
-      specialize (H7 (R_dot_prod_rel_abs_holds    n.+1 i (A2_J A)
-                    (\col_j X_m_jacobi k x0 b A j ord0))).
-      rewrite -H9 in H7. rewrite -H8 in H7. clear H8 H9.
-      specialize (H7 H2). 
-      eapply Rle_lt_trans. apply Rmult_le_compat_l. apply Rabs_pos.
-      apply Rplus_le_compat_l.
-      apply Rle_trans with 
-      ((1 + g ty n.+1) * 
-        Rabs  (\sum_j
-                  Rabs (FT2R (A2_J A (inord i) j)) *
-                  Rabs (FT2R (X_m_jacobi k x0 b A j ord0))) + 
-        g1 ty n.+1 (n.+1 - 1)%coq_nat)%Re.
-      * apply Rle_trans with 
-        (Rabs ( \sum_j
-                  (FT2R (A2_J A (inord i) j) *
-                   FT2R(X_m_jacobi k x0 b A j ord0)))  +
-          (g ty n.+1 *
-              Rabs
-                (\sum_j
-                    Rabs
-                      (FT2R (A2_J A (inord i) j)) *
-                    Rabs
-                      (FT2R
-                         (X_m_jacobi k x0 b A j
-                            ord0))) +
-              g1 ty n.+1 (n.+1 - 1)%coq_nat))%Re.
-        rewrite Rplus_comm.
-        apply Rcomplements.Rle_minus_l.
-        eapply Rle_trans. apply Rabs_triang_inv.
-        apply H7. rewrite -Rplus_assoc. apply Rplus_le_compat_r.
-        rewrite Rmult_plus_distr_r. apply Rplus_le_compat_r.
-        rewrite Rmult_1_l. rewrite Rabs_sum_in.
-        rewrite sum_abs_eq ; last by (intros; apply Rabs_pos).
-        apply /RleP. apply Rabs_ineq.
-      * apply Rle_refl.
-      * rewrite  Rabs_sum_in.
-        rewrite sum_abs_eq ; last by (intros; apply Rabs_pos).
-        (** This gives us information about conditions in terms of 
-            conditions on input
-        **)
-        eapply Rle_lt_trans. apply Rmult_le_compat_l.
-        apply Rabs_pos. rewrite -Rplus_assoc.
-        apply Rplus_le_compat_r. apply Rplus_le_compat_l.
-        apply Rmult_le_compat_l.
-        apply Rplus_le_le_0_compat; try nra; try apply g_pos.
-        apply Rle_trans with 
-            ((vec_inf_norm
-                 (x_fix x (FT2R_mat b) (FT2R_mat A)) +
-                     rho ^ k * f_error 0 b x0 x A +
-                     (1 - rho ^ k) / (1 - rho) * d_mag) * 
-              \sum_j (Rabs ( FT2R (A2_J A (inord i) j))))%Re.
-            ++ apply /RleP. rewrite RmultE.
-               rewrite big_distrr /=.
-               apply big_sum_ge_ex_abstract.
-               intros. rewrite -RmultE.
-               rewrite Rabs_mult. rewrite Rmult_comm.
-               apply Rmult_le_compat_r. apply Rabs_pos.
-               admit. (* apply x_k_bound. apply IHk. *)
-            ++ apply Rle_refl.
-            ++ admit. (* by apply bound_5. *)
-   - by apply Bminus_bplus_opp_implies .
- }
-
-Admitted.
-
 
 
 
@@ -3250,4 +2439,4 @@ intros.
 by apply jacobi_forward_error_bound_aux.
 Qed.
  
-End WITHNANS.                  
+End WITHNANS.

--- a/fma_jacobi_forward_error_sparse.v
+++ b/fma_jacobi_forward_error_sparse.v
@@ -1,0 +1,917 @@
+From Coq Require Import ZArith Reals Psatz.
+From Flocq Require Import Binary.
+From mathcomp Require Import all_ssreflect ssralg ssrnat all_algebra seq matrix.
+From mathcomp Require Import Rstruct.
+Import List ListNotations.
+
+
+From vcfloat Require Import RAux FPStdLib.
+
+Require Import floatlib inf_norm_properties.
+
+Require Import common fma_dot_acc float_acc_lems dotprod_model.
+Require Import fma_matrix_vec_mult vec_sum_inf_norm_rel.
+Require Import fma_real_func_model fma_floating_point_model.
+Require Import fma_jaboci_forward_error.
+
+
+Set Bullet Behavior "Strict Subproofs". 
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+Require Import lemmas fma_is_finite finite_lemmas_additional.
+
+Open Scope ring_scope.
+
+Delimit Scope ring_scope with Ri.
+Delimit Scope R_scope with Re.
+
+Import Order.TTheory GRing.Theory Num.Def Num.Theory.
+
+
+Section WITHNANS.
+Context {NANS: FPCore.Nans}. 
+
+
+Notation "A +f B" := (addmx_float A B) (at level 80).
+Notation "-f A" := (opp_mat A) (at level 50).
+Notation "A *f B" := (mulmx_float A B) (at level 70).
+Notation "A -f B" := (sub_mat A B) (at level 80).
+
+Lemma rho_sparse_ge_0 {ty} {n:nat} 
+  (A: 'M[ftype ty]_n.+1) (b: 'cV[ftype ty]_n.+1) (r : nat):
+  let A_real := FT2R_mat A in
+  let b_real := FT2R_mat b in
+  let R := (vec_inf_norm (A1_diag A_real) * matrix_inf_norm (A2_J_real A_real))%Re in
+  let delta := default_rel ty in
+  let rho := ((((1 + g ty r.+1) * (1 + delta) *
+                  g ty r.+1 + delta * (1 + g ty r.+1) +
+                  g ty r.+1) * (1 + delta) + delta) * R +
+                (((1 + g ty r.+1) * (1 + delta) *
+                  g ty r.+1 + delta * (1 + g ty r.+1) +
+                  g ty r.+1) * default_abs ty +
+                 default_abs ty) *
+                matrix_inf_norm (A2_J_real A_real) + R)%Re in
+ (0 <= rho)%Re.
+Proof.
+ intros.
+ unfold rho.
+ repeat apply Rplus_le_le_0_compat.
+ + apply Rmult_le_pos.
+   - apply Rplus_le_le_0_compat.
+     * apply Rmult_le_pos.
+       ++ apply Rplus_le_le_0_compat; last by apply g_pos.
+          repeat apply Rplus_le_le_0_compat; apply Rmult_le_pos. 
+          -- apply Rmult_le_pos; try apply Rplus_le_le_0_compat; 
+             try nra; try apply g_pos. unfold delta. 
+             apply default_rel_ge_0.
+          -- apply g_pos.
+          -- unfold delta. 
+             apply default_rel_ge_0.
+          -- apply Rplus_le_le_0_compat; last by apply g_pos. nra. 
+       ++ apply Rplus_le_le_0_compat. nra.  
+          unfold delta. 
+          apply default_rel_ge_0.
+     * unfold delta. 
+       apply default_rel_ge_0.
+   - unfold R2. apply Rmult_le_pos.
+     * apply /RleP. apply vec_norm_pd.
+     * apply /RleP. apply matrix_norm_pd.
+ + apply Rmult_le_pos.
+   - repeat apply Rplus_le_le_0_compat; last by apply default_abs_ge_0.
+     apply Rmult_le_pos; last by apply default_abs_ge_0.
+     apply Rplus_le_le_0_compat; last by apply g_pos.
+     apply Rplus_le_le_0_compat. 
+     * repeat apply Rmult_le_pos.
+       ++ apply Rplus_le_le_0_compat; last by apply g_pos. nra. 
+       ++ apply Rplus_le_le_0_compat. nra.  
+          unfold delta. 
+          apply default_rel_ge_0.
+       ++ apply g_pos.
+     * apply Rmult_le_pos.
+       ++ unfold delta. 
+          apply default_rel_ge_0.
+       ++ apply Rplus_le_le_0_compat; last by apply g_pos. nra.
+   - apply /RleP. apply matrix_norm_pd.
+ + unfold R2. apply Rmult_le_pos.
+     * apply /RleP. apply vec_norm_pd.
+     * apply /RleP. apply matrix_norm_pd.
+Qed.
+
+Definition rho_def_sparse  {t: type} {n:nat} 
+  (A: 'M[ftype t]_n.+1) (b: 'cV[ftype t]_n.+1) 
+  (r : nat) :=
+  let A_real := FT2R_mat A in
+  let b_real := FT2R_mat b in  
+  let R := (vec_inf_norm (A1_diag A_real) * matrix_inf_norm (A2_J_real A_real))%Re in
+  let delta := default_rel t in
+  ((((1 + g t r.+1) * (1 + delta) *
+                  g t r.+1 + delta * (1 + g t r.+1) +
+                  g t r.+1) * (1 + delta) + delta) * R +
+                (((1 + g t r.+1) * (1 + delta) *
+                  g t r.+1 + delta * (1 + g t r.+1) +
+                  g t r.+1) * default_abs t +
+                 default_abs t) *
+                matrix_inf_norm (A2_J_real A_real) + R)%Re.
+
+Definition d_mag_def_sparse {t: type} {n:nat} 
+  (A: 'M[ftype t]_n.+1) (b: 'cV[ftype t]_n.+1) 
+  (r : nat) :=
+  let A_real := FT2R_mat A in
+  let b_real := FT2R_mat b in  
+  let x:= mulmx (A_real^-1) b_real in
+  let R := (vec_inf_norm (A1_diag A_real) * matrix_inf_norm (A2_J_real A_real))%Re in
+  let delta := default_rel t in
+  ((g t r.+1 * (1 + delta) + delta) *
+                    ((vec_inf_norm (A1_diag A_real) *
+                      (1 + delta) + default_abs t) *
+                     vec_inf_norm b_real) +
+                    (1 + g t r.+1) * g1 t r.+1 (r.+1 - 1) *
+                    (1 + delta) *
+                    (vec_inf_norm (A1_diag A_real) *
+                     (1 + delta) + default_abs t) +
+                    g1 t r.+1 (r.+1 - 1) +
+                    (vec_inf_norm (A1_diag A_real) * delta +
+                     default_abs t) * vec_inf_norm b_real +
+                    ((((1 + g t r.+1) * (1 + delta) *
+                       g t r.+1 + delta * (1 + g t r.+1) +
+                       g t r.+1) * (1 + delta) + delta) * R +
+                     (((1 + g t r.+1) * (1 + delta) *
+                       g t r.+1 + delta * (1 + g t r.+1) +
+                       g t r.+1) * default_abs t +
+                      default_abs t) *
+                     matrix_inf_norm (A2_J_real A_real)) *
+                    vec_inf_norm (x_fix x b_real A_real))%Re.
+
+Lemma d_mag_sparse_ge_0 {t: type} {n:nat} (A: 'M[ftype t]_n.+1) 
+  (b: 'cV[ftype t]_n.+1) (r : nat) :
+  (0 <= d_mag_def_sparse A b r)%Re.
+Proof.
+  unfold d_mag_def_sparse.
+  repeat apply Rplus_le_le_0_compat.
+  + repeat try apply Rmult_le_pos; try repeat apply Rplus_le_le_0_compat.
+    - apply Rmult_le_pos; try apply g_pos.
+      apply Rplus_le_le_0_compat; try nra; try apply default_rel_ge_0.
+    - apply default_rel_ge_0.
+    - apply Rmult_le_pos. 
+      apply /RleP. apply vec_norm_pd.
+      apply Rplus_le_le_0_compat. nra. apply default_rel_ge_0.
+    - apply default_abs_ge_0.
+    - apply /RleP. apply vec_norm_pd.
+  + repeat try apply Rmult_le_pos.
+    - apply Rplus_le_le_0_compat. nra. apply g_pos.
+    - apply pos_INR.
+    - nra.
+    - apply bpow_ge_0.
+    - apply Rplus_le_le_0_compat. nra. apply g_pos.
+    - apply Rplus_le_le_0_compat. nra. apply default_rel_ge_0. 
+    - apply Rplus_le_le_0_compat; last by apply default_abs_ge_0.
+      apply Rmult_le_pos; last by (apply Rplus_le_le_0_compat; try nra; try apply default_rel_ge_0).
+      apply /RleP. apply vec_norm_pd.
+  + apply g1_pos.
+  + apply Rmult_le_pos; last by (apply /RleP; try apply vec_norm_pd).
+    apply Rplus_le_le_0_compat; last by apply default_abs_ge_0.
+    apply Rmult_le_pos; last by apply default_rel_ge_0.
+    apply /RleP. apply vec_norm_pd.
+  + repeat apply Rmult_le_pos; last by (apply /RleP; try apply vec_norm_pd).
+    repeat apply Rplus_le_le_0_compat.
+    - repeat apply Rmult_le_pos.
+      * repeat apply Rplus_le_le_0_compat; last by apply default_rel_ge_0.
+        repeat apply Rmult_le_pos.
+        ++ apply Rplus_le_le_0_compat; last by apply g_pos.
+           apply Rplus_le_le_0_compat.
+           -- repeat apply Rmult_le_pos;last by apply g_pos.
+              apply Rplus_le_le_0_compat; try nra; try apply g_pos.
+              apply Rplus_le_le_0_compat; try nra; try apply default_rel_ge_0.
+           -- apply Rmult_le_pos; first by apply default_rel_ge_0.
+              apply Rplus_le_le_0_compat; try nra; try apply g_pos.
+        ++ apply Rplus_le_le_0_compat. nra. apply default_rel_ge_0.
+      * apply /RleP. apply vec_norm_pd.
+      * apply /RleP. apply matrix_norm_pd.
+    - repeat apply Rmult_le_pos; last by (apply /RleP; apply matrix_norm_pd).
+      repeat apply Rplus_le_le_0_compat; last by apply default_abs_ge_0.
+      repeat apply Rmult_le_pos; last by apply bpow_ge_0.
+      * apply Rplus_le_le_0_compat;last by apply g_pos.
+        apply Rplus_le_le_0_compat.
+        ++ repeat apply Rmult_le_pos;last by apply g_pos.
+           apply Rplus_le_le_0_compat; try nra; try apply g_pos.
+           apply Rplus_le_le_0_compat; try nra; try apply default_rel_ge_0.
+        ++ apply Rmult_le_pos; first by apply default_rel_ge_0.
+           apply Rplus_le_le_0_compat. nra. apply g_pos.
+      * nra.
+Qed.
+
+Lemma x_k_bound_sparse {ty} {n:nat} 
+  (A: 'M[ftype ty]_n.+1) (x0 b: 'cV[ftype ty]_n.+1) 
+  (r : nat) (HA : is_r_sparse_mat A r) k i:
+  let A_real := FT2R_mat A in
+  let b_real := FT2R_mat b in
+  let x:= A_real^-1 *m b_real in
+  let rho := rho_def_sparse A b r in 
+  let d_mag := d_mag_def_sparse A b r in 
+   (f_error k b x0 x A <=
+       rho ^ k * f_error 0 b x0 x A +
+       (1 - rho ^ k) / (1 - rho) * d_mag)%Re ->
+    (Rabs (FT2R (X_m_jacobi k x0 b A i ord0)) <= 
+      vec_inf_norm
+         (x_fix x (FT2R_mat b) (FT2R_mat A)) +
+       rho ^ k * f_error 0 b x0 x A +
+       (1 - rho ^ k) / (1 - rho) * d_mag)%Re.
+Proof.
+intros.
+rewrite [in X in (X <= _)%Re]/f_error in H.
+apply Rle_trans with 
+  (vec_inf_norm (FT2R_mat (X_m_jacobi k x0 b A))).
+  - unfold vec_inf_norm.
+    apply Rle_trans with 
+     [seq Rabs
+          (FT2R_mat (X_m_jacobi k x0 b A)
+             i0 0)
+          | i0 <- enum 'I_n.+1]`_i.
+    * rewrite seq_equiv. rewrite nth_mkseq; 
+      last by apply ltn_ord.
+      rewrite mxE. rewrite inord_val. apply Rle_refl.
+    * apply /RleP.
+      apply (@bigmaxr_ler  _ 0%Re [seq Rabs
+                                   (FT2R_mat (X_m_jacobi k x0 b A) i0 0)
+                               | i0 <- enum 'I_n.+1] i).
+      rewrite size_map size_enum_ord.
+      by apply ltn_ord.
+  - assert (forall x y z d: R, (x - y <= z + d)%Re -> (x <= y + z + d)%Re).
+    { intros. nra. } apply H0.
+    apply /RleP. apply reverse_triang_ineq.
+    by apply /RleP.
+Qed.
+
+Lemma bound_1_sparse  {t: type} {n:nat}
+  (A : 'M[ftype t]_n.+1) (x0 b : 'cV[ftype t]_n.+1) (k:nat) m
+  (r : nat) (HA : is_r_sparse_mat A r):
+  let A_real := FT2R_mat A in
+  let b_real := FT2R_mat b in
+  let x:= A_real^-1 *m b_real in
+  let rho := rho_def_sparse A b r in 
+  let d_mag := d_mag_def_sparse A b r in 
+  input_bound A x0 b ->
+  (rho < 1)%Re ->
+  (0 < f_error 0 b x0 x A -
+         d_mag_def A b * / (1 - rho_def_sparse A b r))%Re ->
+  (Rabs (FT2R (A (inord m) (inord m))) *
+   (rho ^ k * (1 + rho) *
+    (f_error 0 b x0 x A -
+     d_mag * / (1 - rho)) +
+    2 * d_mag * / (1 - rho) +
+    2 *
+    vec_inf_norm
+      (x_fix x (FT2R_mat b) (FT2R_mat A))) <
+   (sqrt (fun_bnd t n.+1) - default_abs t) /
+   (1 + default_rel t) /
+   (1 + default_rel t))%Re.
+Proof.
+intros.
+unfold input_bound in H.
+destruct H as [bnd1 H]. clear H.
+apply Rle_lt_trans with 
+(Rabs (FT2R (A (inord m) (inord m))) *
+        (1 * (1 + rho_def_sparse A b r) *
+         (f_error 0 b x0
+            ((FT2R_mat A)^-1 *m 
+             FT2R_mat b) A -
+          d_mag_def A b *
+          / (1 - rho_def_sparse A b r)) +
+         2 * d_mag_def A b *
+         / (1 - rho_def_sparse A b r) +
+         2 *
+         vec_inf_norm
+           (x_fix
+              ((FT2R_mat A)^-1 *m FT2R_mat b)
+              (FT2R_mat b) (FT2R_mat A))))%Re.
++ apply Rmult_le_compat_l. apply Rabs_pos.
+  change (_ *m _) with x.
+ (* unfold d_mag.*)
+  fold rho in H1|-*.
+  set v := vec_inf_norm _.
+  replace (d_mag_def _ _) with d_mag in H1|- * by admit.
+  replace rho with (rho_def A b) in * by admit. clear rho.
+  repeat apply Rplus_le_compat_r.
+  apply Rmult_le_compat_r. apply Rlt_le. apply H1.
+  apply Rmult_le_compat_r.
+  apply Rplus_le_le_0_compat. nra. 
+ by apply rho_ge_0.
+  assert ( 1%Re = (1 ^ k)%Re) by (rewrite pow1; nra).
+  rewrite H. apply pow_incr.
+  split. by apply rho_ge_0.
+  apply Rlt_le. apply H0.
++ fold rho.
+  replace rho with (rho_def A b) by admit. 
+ apply bnd1.
+Admitted.
+
+Lemma bound_2_sparse {ty} {n:nat} 
+  (A: 'M[ftype ty]_n.+1) (x0 b: 'cV[ftype ty]_n.+1) k
+  (r : nat) (HA : is_r_sparse_mat A r):
+  let A_real := FT2R_mat A in
+  let b_real := FT2R_mat b in
+  let x:= A_real^-1 *m b_real in
+  let rho := rho_def_sparse A b r in 
+  let d_mag := d_mag_def_sparse A b r in 
+  input_bound_sparse A x0 b r ->
+  (rho < 1)%Re ->
+  (vec_inf_norm
+   (x_fix x (FT2R_mat b) (FT2R_mat A)) +
+       rho ^ k *
+       f_error 0 b x0 x A +
+       (1 - rho ^ k) / (1 - rho) *
+       d_mag < sqrt (fun_bnd ty r.+1))%Re.
+Proof. 
+intros.
+unfold input_bound in H.
+destruct H as [_ [bnd2 H]]. clear H.
+apply Rle_lt_trans with
+(vec_inf_norm
+          (x_fix
+             ((FT2R_mat A)^-1 *m 
+              FT2R_mat b)
+             (FT2R_mat b)
+             (FT2R_mat A)) +
+        1 * f_error 0 b x0
+          ((FT2R_mat A)^-1 *m 
+           FT2R_mat b) A +
+        1 / (1 - rho_def_sparse A b r) * d_mag_def_sparse A b r)%Re.
++ unfold x. unfold A_real, b_real. rewrite Rplus_assoc.
+  rewrite Rplus_assoc.
+  apply Rplus_le_compat_l. unfold rho, d_mag.
+  apply Rplus_le_compat.
+  - apply Rmult_le_compat_r.
+    * unfold f_error. apply /RleP.
+      apply vec_norm_pd.
+    * assert ( 1%Re = (1 ^ k)%Re) by (rewrite pow1; nra).
+      rewrite H. apply pow_incr.
+      split. by apply rho_sparse_ge_0.
+      apply Rlt_le. apply H0.
+  - apply Rmult_le_compat_r.
+    apply d_mag_sparse_ge_0. apply Rmult_le_compat_r.
+    apply Rlt_le. apply Rinv_0_lt_compat.
+    apply Rlt_Rminus. apply H0.
+    apply Rcomplements.Rle_minus_l.
+    assert (forall a b:R, (0 <= b)%Re -> (a <= a + b)%Re).
+    { intros. nra. } apply H.
+    apply pow_le. by apply rho_sparse_ge_0.
++ apply bnd2.
+Qed.
+
+Lemma bound_3_sparse {ty} {n:nat} 
+  (A: 'M[ftype ty]_n.+1) (x0 b: 'cV[ftype ty]_n.+1) (r : nat):
+  input_bound_sparse A x0 b r ->
+  forall i j, 
+  (Rabs (FT2R (A2_J A i j )) <
+    sqrt (fun_bnd ty r.+1))%Re.
+Proof.
+intros. unfold input_bound_sparse in H.
+destruct H as [_ [_ [bnd3 H]]]. clear H.
+apply bnd3. 
+Qed.
+
+Definition forward_error_cond_sparse {ty} {n:nat} 
+  (A: 'M[ftype ty]_n.+1) (x0 b: 'cV[ftype ty]_n.+1) (r : nat) :=
+  let rho := rho_def_sparse A b r in
+  let d_mag := d_mag_def_sparse A b r in
+   let A_real := FT2R_mat A in
+  (forall i, finite (A i i)) /\
+  (rho < 1)%Re /\
+  A_real \in unitmx /\
+  (forall i : 'I_n.+1, finite (BDIV (Zconst ty 1) (A i i))) /\
+  (forall i : 'I_n.+1, finite (x0 i ord0)) /\
+  (forall i, finite  (A1_inv_J A i ord0)) /\
+  (forall i j, finite (A2_J A i j)) /\ 
+  (forall i, finite (b i ord0)) /\
+  @size_constraint ty n /\
+  input_bound_sparse A x0 b r.
+
+  Theorem jacobi_forward_error_bound_sparse_aux {ty} {n : nat}
+  (A: 'M[ftype ty]_n.+1) (b: 'cV[ftype ty]_n.+1)
+  (r : nat) (HA : is_r_sparse_mat A r):
+  let A_real := FT2R_mat A in 
+  let b_real := FT2R_mat b in 
+  let x := A_real^-1 *m b_real in 
+  let R := (vec_inf_norm (A1_diag A_real) * matrix_inf_norm (A2_J_real A_real))%Re in
+   let delta := default_rel ty in
+   let rho := ((((1 + g ty r.+1) * (1 + delta) *
+                  g ty r.+1 + delta * (1 + g ty r.+1) +
+                  g ty r.+1) * (1 + delta) + delta) * R +
+                (((1 + g ty r.+1) * (1 + delta) *
+                  g ty r.+1 + delta * (1 + g ty r.+1) +
+                  g ty r.+1) * default_abs ty +
+                 default_abs ty) *
+                matrix_inf_norm (A2_J_real A_real) + R)%Re in
+   let d_mag := ((g ty r.+1 * (1 + delta) + delta) *
+                    ((vec_inf_norm (A1_diag A_real) *
+                      (1 + delta) + default_abs ty) *
+                     vec_inf_norm b_real) +
+                    (1 + g ty r.+1) * g1 ty r.+1 (r.+1 - 1) *
+                    (1 + delta) *
+                    (vec_inf_norm (A1_diag A_real) *
+                     (1 + delta) + default_abs ty) +
+                    g1 ty r.+1 (r.+1 - 1) +
+                    (vec_inf_norm (A1_diag A_real) * delta +
+                     default_abs ty) * vec_inf_norm b_real +
+                    ((((1 + g ty r.+1) * (1 + delta) *
+                       g ty r.+1 + delta * (1 + g ty r.+1) +
+                       g ty r.+1) * (1 + delta) + delta) * R +
+                     (((1 + g ty r.+1) * (1 + delta) *
+                       g ty r.+1 + delta * (1 + g ty r.+1) +
+                       g ty r.+1) * default_abs ty +
+                      default_abs ty) *
+                     matrix_inf_norm (A2_J_real A_real)) *
+                    vec_inf_norm (x_fix x b_real A_real))%Re in
+  forall x0: 'cV[ftype ty]_n.+1,
+  forward_error_cond_sparse A x0 b r ->
+  (forall k:nat, 
+   (forall i, finite (X_m_jacobi k x0 b A i ord0)) /\
+   (f_error k b x0 x A <= rho^k * (f_error 0 b x0 x A) + ((1 - rho^k) / (1 - rho))* d_mag)%Re).
+Proof.
+  intros ? ? ? ? ? ? ? ? Hcond.
+  unfold forward_error_cond_sparse in Hcond.
+  destruct Hcond as [HAf [H [H0 [Hdivf [Hx0 [Ha1_inv [HfA2 [Hb [size_cons Hinp]]]]]]]]].
+  assert (forall i : 'I_n.+1, FT2R (A i i) <> 0%Re).
+  { intros. by apply BDIV_FT2R_sep_zero. }
+  induction k.
+  { split; simpl; try nra. intros. apply Hx0. }
+  assert (Hfin: (forall i : 'I_n.+1, finite (X_m_jacobi k.+1 x0 b A i ord0))).
+  { intros. simpl.
+    unfold jacobi_iter.
+    rewrite mxE.
+    rewrite nth_vec_to_list_float; last by apply ltn_ord.
+    assert (finite 
+              (let l1 :=
+                 vec_to_list_float n.+1
+                   (\row_j A2_J A (inord i) j)^T in
+               let l2 :=
+                 vec_to_list_float n.+1
+                   (\col_j X_m_jacobi k x0 b A j
+                             ord0) in
+               dotprod_r l1 l2)).
+    { pose proof (@finite_fma_from_bounded _ ty).
+      specialize (H2 (vec_to_list_float n.+1
+                         (\row_j A2_J A (inord i) j)^T)
+                      ( vec_to_list_float n.+1
+                          (\col_j X_m_jacobi k x0 b A j ord0))).
+      rewrite combine_length !length_veclist Nat.min_id in H2.
+      specialize (H2 (dotprod_r 
+                            (vec_to_list_float n.+1
+                                (\row_j A2_J A (inord i) j)^T)
+                            (vec_to_list_float n.+1
+                                 (\col_j X_m_jacobi k x0 b A j  ord0)))).
+      specialize (H2 (@fma_dot_prod_rel_holds _ _ _ n.+1 i (A2_J A) 
+                          (\col_j X_m_jacobi k x0 b A j ord0))).
+
+      (* modifications start here! *)
+      assert ((g1 ty (n.+2 +1)%coq_nat n.+2 <= fmax ty)%Re).
+      { by apply g1_constraint_Sn. } specialize (H2 H3).
+      apply H2. intros.
+      repeat split.
+      + destruct x1. simpl. apply in_combine_l in H4.
+        apply in_rev in H4.
+        pose proof (@In_nth _ (rev (vec_to_list_float n.+1
+                                 (\row_j A2_J A (inord i) j)^T)) f (Zconst ty 0) H4).
+        destruct H5 as [m [H51 H52]]. rewrite rev_nth in H52.
+        rewrite length_veclist in H52.
+        assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat) by lia.
+        rewrite H5 in H52. rewrite nth_vec_to_list_float  in H52.
+        - rewrite mxE in H52. rewrite mxE in H52. rewrite -H52. apply HfA2.
+        - rewrite rev_length length_veclist in H51. by apply /ssrnat.ltP. 
+        - rewrite rev_length in H51. apply H51.
+      + destruct x1. simpl. apply in_combine_r in H4.
+        apply in_rev in H4.
+        pose proof (@In_nth _ (rev
+                                (vec_to_list_float n.+1
+                                   (\col_j X_m_jacobi k x0 b A j ord0))) f0 (Zconst ty 0) H4).
+        destruct H5 as [m [H51 H52]]. rewrite rev_nth in H52.
+        rewrite length_veclist in H52.
+        assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat) by lia.
+        rewrite H5 in H52. rewrite nth_vec_to_list_float  in H52.
+        - rewrite mxE in H52. rewrite -H52. apply IHk.
+        - rewrite rev_length length_veclist in H51. by apply /ssrnat.ltP. 
+        - rewrite rev_length in H51. apply H51.
+      + destruct x1. simpl. apply in_combine_l in H4.
+        apply in_rev in H4.
+        pose proof (@In_nth _ (rev (vec_to_list_float n.+1
+                                 (\row_j A2_J A (inord i) j)^T)) f (Zconst ty 0) H4).
+        destruct H5 as [m [H51 H52]]. rewrite rev_nth in H52.
+        rewrite length_veclist in H52.
+        assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat) by lia.
+        rewrite H5 in H52. rewrite nth_vec_to_list_float  in H52.
+        - rewrite mxE in H52. rewrite mxE in H52. rewrite -H52. 
+          apply bound_3_sparse with x0 b.
+          admit.
+        - rewrite rev_length length_veclist in H51. by apply /ssrnat.ltP. 
+        - rewrite rev_length in H51. apply H51.
+      + destruct x1. simpl. apply in_combine_r in H4.
+        apply in_rev in H4.
+        pose proof (@In_nth _ (rev
+                                (vec_to_list_float n.+1
+                                   (\col_j X_m_jacobi k x0 b A j ord0))) f0 (Zconst ty 0) H4).
+        destruct H5 as [m [H51 H52]]. rewrite rev_nth in H52.
+        rewrite length_veclist in H52.
+        assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat) by lia.
+        rewrite H5 in H52. rewrite nth_vec_to_list_float  in H52.
+        - rewrite mxE in H52. rewrite -H52.
+          destruct IHk as [IHk1 IHk2].
+          apply (x_k_bound_sparse HA (@inord n m)) in IHk2.
+          eapply Rle_lt_trans.
+          apply IHk2. admit. (*by apply bound_2_sparse.*)
+        - rewrite rev_length length_veclist in H51. by apply /ssrnat.ltP. 
+        - rewrite rev_length in H51. apply H51.
+    }
+    assert (finite 
+            (BMINUS (b (inord i) ord0)
+               ((A2_J A *f X_m_jacobi k x0 b A)
+                  (inord i) ord0))).
+    { apply Bplus_bminus_opp_implies.
+      apply BPLUS_no_overflow_is_finite.
+        + apply Hb.
+        + rewrite finite_BOPP. rewrite mxE. apply H2.
+        + unfold Bplus_no_overflow. 
+          pose proof (@generic_round_property ty).
+          specialize (H3 (FT2R (b (inord i) ord0) +
+                             FT2R
+                               (BOPP
+                                  ((A2_J A *f
+                                    X_m_jacobi k x0 b A)
+                                     (inord i) ord0)))%Re).
+          destruct H3 as [d1 [e1 [Hde1 [Hd1 [He1 H3]]]]].
+          rewrite H3.
+          eapply Rle_lt_trans. apply Rabs_triang.
+          eapply Rle_lt_trans. apply Rplus_le_compat_l.
+          apply He1. apply Rcomplements.Rlt_minus_r.
+          rewrite Rabs_mult.
+          eapply Rle_lt_trans.
+          apply Rmult_le_compat_l. apply Rabs_pos.
+          eapply Rle_trans. apply Rabs_triang.
+          rewrite Rabs_R1. apply Rplus_le_compat_l. apply Hd1.
+          apply Rcomplements.Rlt_div_r.
+          apply Rplus_lt_le_0_compat; try nra; try apply default_rel_ge_0.
+          eapply Rle_lt_trans. apply Rabs_triang.
+          rewrite [in X in (_ + X < _)%Re]/FT2R B2R_Bopp Rabs_Ropp.
+          fold (@FT2R ty). rewrite mxE.
+          pose proof (@fma_dotprod_forward_error _ ty).
+          specialize (H4 (vec_to_list_float n.+1
+                                  (\row_j A2_J A (inord i) j)^T)
+                         (vec_to_list_float n.+1
+                            (\col_j X_m_jacobi k x0 b A j  ord0))).
+          rewrite !length_veclist in H4.
+          assert (n.+1 = n.+1). { lia. } specialize (H4 H5). 
+          clear H5.
+          specialize (H4 (dotprod_r 
+                            (vec_to_list_float n.+1
+                                (\row_j A2_J A (inord i) j)^T)
+                            (vec_to_list_float n.+1
+                                 (\col_j X_m_jacobi k x0 b A j  ord0)))).
+          specialize (H4 
+                     (\sum_j ( (FT2R (A2_J A (inord i) j)) * 
+                               (FT2R (X_m_jacobi k x0 b A j ord0)))%Re)).
+          specialize (H4
+                     (\sum_j (Rabs (FT2R (A2_J A (inord i) j)) * 
+                              Rabs (FT2R (X_m_jacobi k x0 b A j ord0)))%Re)).
+          specialize (H4 (@fma_dot_prod_rel_holds _ _ _ n.+1 i (A2_J A) 
+                          (\col_j X_m_jacobi k x0 b A j ord0))).
+          assert (\sum_j
+                     (FT2R
+                        (A2_J A (inord i) j) *
+                      FT2R
+                        (X_m_jacobi k x0 b
+                           A j ord0))%Re = 
+                  \sum_(j < n.+1)
+                          FT2R_mat (A2_J A) (inord i) (@widen_ord n.+1 n.+1 (leqnn n.+1) j) * 
+                          FT2R_mat (\col_j X_m_jacobi k x0 b A j ord0) (@widen_ord n.+1 n.+1 (leqnn n.+1) j) ord0).
+          { apply eq_big. intros. by []. intros.
+            assert ((widen_ord (m:=n.+1) (leqnn n.+1) i0) = i0).
+            { unfold widen_ord. 
+              apply val_inj. by simpl. 
+            } rewrite H6. by rewrite !mxE.
+          } rewrite H5 in H4.
+          specialize (H4 (@R_dot_prod_rel_holds _ _  n.+1 i (leqnn n.+1) (A2_J A)
+                        (\col_j X_m_jacobi k x0 b A j ord0))). 
+          assert (\sum_j
+                     (Rabs
+                        (FT2R
+                           (A2_J A 
+                              (inord i) j)) *
+                      Rabs
+                        (FT2R
+                           (X_m_jacobi k
+                              x0 b A j ord0))) =  
+                  sum_fold
+                    (map (uncurry Rmult)
+                       (map Rabsp
+                          (map FR2
+                             (combine
+                                (vec_to_list_float n.+1
+                                   (\row_j (A2_J A) (inord i) j)^T)
+                                (vec_to_list_float n.+1 
+                                  (\col_j X_m_jacobi k x0 b A j ord0))))))).
+          { rewrite -sum_fold_mathcomp_equiv.
+            apply eq_big. by []. intros.
+            assert ((widen_ord (m:=n.+1) (leqnn n.+1) i0) = i0).
+            { unfold widen_ord. 
+              apply val_inj. by simpl. 
+            } rewrite H7. by rewrite !mxE.
+          } rewrite H6 in H4.
+          specialize (H4 (R_dot_prod_rel_abs_holds    n.+1 i (A2_J A)
+                        (\col_j X_m_jacobi k x0 b A j ord0))).
+          rewrite -H6 in H4. rewrite -H5 in H4. clear H5 H6.
+          specialize (H4 H2). 
+          eapply Rle_lt_trans. apply Rplus_le_compat_l. 
+          apply Rle_trans with 
+          ((1 + g ty n.+1) * 
+            Rabs  (\sum_j
+                      Rabs (FT2R (A2_J A (inord i) j)) *
+                      Rabs (FT2R (X_m_jacobi k x0 b A j ord0))) + 
+            g1 ty n.+1 (n.+1 - 1)%coq_nat)%Re.
+          * apply Rle_trans with 
+            (Rabs ( \sum_j
+                      (FT2R (A2_J A (inord i) j) *
+                       FT2R(X_m_jacobi k x0 b A j ord0)))  +
+              (g ty n.+1 *
+                  Rabs
+                    (\sum_j
+                        Rabs
+                          (FT2R (A2_J A (inord i) j)) *
+                        Rabs
+                          (FT2R
+                             (X_m_jacobi k x0 b A j
+                                ord0))) +
+                  g1 ty n.+1 (n.+1 - 1)%coq_nat))%Re.
+            rewrite Rplus_comm.
+            apply Rcomplements.Rle_minus_l.
+            eapply Rle_trans. apply Rabs_triang_inv.
+            apply H4. rewrite -Rplus_assoc. apply Rplus_le_compat_r.
+            rewrite Rmult_plus_distr_r. apply Rplus_le_compat_r.
+            rewrite Rmult_1_l. rewrite Rabs_sum_in.
+            rewrite sum_abs_eq ; last by (intros; apply Rabs_pos).
+            apply /RleP. apply Rabs_ineq.
+          * apply Rle_refl.
+          * rewrite Rabs_sum_in. rewrite sum_abs_eq; last by (intros; apply Rabs_pos).
+            eapply Rle_lt_trans. rewrite -Rplus_assoc. apply Rplus_le_compat_r.
+            apply Rplus_le_compat_l.
+            apply Rmult_le_compat_l.
+            apply Rplus_le_le_0_compat; try nra; try apply g_pos.
+            apply Rle_trans with 
+            ((vec_inf_norm
+                 (x_fix x (FT2R_mat b) (FT2R_mat A)) +
+                     rho ^ k * f_error 0 b x0 x A +
+                     (1 - rho ^ k) / (1 - rho) * d_mag) * 
+              \sum_j (Rabs ( FT2R (A2_J A (inord i) j))))%Re.
+            ++ apply /RleP. rewrite RmultE.
+               rewrite big_distrr /=.
+               apply big_sum_ge_ex_abstract.
+               intros. rewrite -RmultE.
+               rewrite Rabs_mult. rewrite Rmult_comm.
+               apply Rmult_le_compat_r. apply Rabs_pos.
+               admit. (* apply x_k_bound. apply IHk. *)
+            ++ apply Rle_refl.
+            ++ admit. (* by apply bound_4. *)
+    }
+    apply BMULT_no_overflow_is_finite.
+    + apply Ha1_inv.
+    + rewrite nth_vec_to_list_float; last by apply ltn_ord.
+      rewrite mxE. apply H3.
+    + rewrite nth_vec_to_list_float; last by apply ltn_ord.
+      unfold Bmult_no_overflow.
+      unfold rounded.
+      pose proof (@generic_round_property ty 
+                  (FT2R (A1_inv_J A (inord i) ord0) *
+                     FT2R
+                       ((b -f
+                         A2_J A *f X_m_jacobi k x0 b A)
+                          (inord i) ord0))).
+      destruct H4 as [d [e [Hde [Hd [He H4]]]]].
+      rewrite H4. 
+      eapply Rle_lt_trans.
+      apply Rabs_triang. eapply Rle_lt_trans.
+      apply Rplus_le_compat_l. apply He.
+      apply Rcomplements.Rlt_minus_r. rewrite Rabs_mult.
+      eapply Rle_lt_trans. apply Rmult_le_compat_l. apply Rabs_pos.
+      apply Rle_trans with (Rabs 1 + Rabs d)%Re.
+      apply Rabs_triang. rewrite Rabs_R1.
+      apply Rplus_le_compat_l. apply Hd. 
+      apply Rcomplements.Rlt_div_r.
+      apply Rplus_lt_le_0_compat; try nra; try apply default_rel_ge_0.
+      rewrite Rabs_mult. rewrite [in X in (_ * X < _)%Re]mxE. 
+      rewrite Bminus_bplus_opp_equiv.
+      pose proof (@BPLUS_accurate' _ ty).
+      specialize (H5 (b (inord i) ord0) (BOPP 
+            ((A2_J A *f X_m_jacobi k x0 b A)
+                          (inord i) ord0))).
+      assert (finite
+               (BPLUS (b (inord i) ord0)
+                  (BOPP
+                     ((A2_J A *f
+                       X_m_jacobi k x0 b A)
+                        (inord i) ord0)))).
+      { by apply Bminus_bplus_opp_implies . }
+      specialize (H5 H6).
+      destruct H5 as [d1 [Hd1 H5]].
+      rewrite H5.
+      - rewrite Rabs_mult. eapply Rle_lt_trans.
+        apply Rmult_le_compat_l. apply Rabs_pos.
+        apply Rmult_le_compat_l. apply Rabs_pos.
+        apply Rle_trans with (Rabs 1 + Rabs d1)%Re.
+        apply Rabs_triang. rewrite Rabs_R1. apply Rplus_le_compat_l.
+        apply Hd1. rewrite -Rmult_assoc.
+        apply Rcomplements.Rlt_div_r.
+        apply Rplus_lt_le_0_compat; try nra; try apply default_rel_ge_0.
+        eapply Rle_lt_trans. apply Rmult_le_compat_l.
+        apply Rabs_pos. apply Rabs_triang.
+        rewrite [in X in (_ * (_ + X) < _)%Re]/FT2R B2R_Bopp.
+        rewrite Rabs_Ropp. fold (@FT2R ty).
+        rewrite [in X in (_ * (_ + X) < _)%Re]mxE.
+        pose proof (@fma_dotprod_forward_error _ ty).
+        specialize (H7 (vec_to_list_float n.+1
+                                (\row_j A2_J A (inord i) j)^T)
+                       (vec_to_list_float n.+1
+                          (\col_j X_m_jacobi k x0 b A j  ord0))).
+        rewrite !length_veclist in H7.
+        assert (n.+1 = n.+1). { lia. } specialize (H7 H8). 
+        clear H8.
+        specialize (H7 (dotprod_r 
+                          (vec_to_list_float n.+1
+                              (\row_j A2_J A (inord i) j)^T)
+                          (vec_to_list_float n.+1
+                               (\col_j X_m_jacobi k x0 b A j  ord0)))).
+       specialize (H7 
+                   (\sum_j ( (FT2R (A2_J A (inord i) j)) * 
+                             (FT2R (X_m_jacobi k x0 b A j ord0)))%Re)).
+      specialize (H7 
+                   (\sum_j (Rabs (FT2R (A2_J A (inord i) j)) * 
+                            Rabs (FT2R (X_m_jacobi k x0 b A j ord0)))%Re)).
+      specialize (H7 (@fma_dot_prod_rel_holds _ _ _ n.+1 i (A2_J A) 
+                        (\col_j X_m_jacobi k x0 b A j ord0))).
+      assert (\sum_j
+                 (FT2R
+                    (A2_J A (inord i) j) *
+                  FT2R
+                    (X_m_jacobi k x0 b
+                       A j ord0))%Re = 
+              \sum_(j < n.+1)
+                      FT2R_mat (A2_J A) (inord i) (@widen_ord n.+1 n.+1 (leqnn n.+1) j) * 
+                      FT2R_mat (\col_j X_m_jacobi k x0 b A j ord0) (@widen_ord n.+1 n.+1 (leqnn n.+1) j) ord0).
+      { apply eq_big. intros. by []. intros.
+        assert ((widen_ord (m:=n.+1) (leqnn n.+1) i0) = i0).
+        { unfold widen_ord. 
+          apply val_inj. by simpl. 
+        } rewrite H9. by rewrite !mxE.
+      } rewrite H8 in H7.
+      specialize (H7 (@R_dot_prod_rel_holds _ _  n.+1 i (leqnn n.+1) (A2_J A)
+                    (\col_j X_m_jacobi k x0 b A j ord0))). 
+      assert (\sum_j
+                 (Rabs
+                    (FT2R
+                       (A2_J A 
+                          (inord i) j)) *
+                  Rabs
+                    (FT2R
+                       (X_m_jacobi k
+                          x0 b A j ord0))) =  
+              sum_fold
+                (map (uncurry Rmult)
+                   (map Rabsp
+                      (map FR2
+                         (combine
+                            (vec_to_list_float n.+1
+                               (\row_j (A2_J A) (inord i) j)^T)
+                            (vec_to_list_float n.+1 
+                              (\col_j X_m_jacobi k x0 b A j ord0))))))).
+      { rewrite -sum_fold_mathcomp_equiv.
+        apply eq_big. by []. intros.
+        assert ((widen_ord (m:=n.+1) (leqnn n.+1) i0) = i0).
+        { unfold widen_ord. 
+          apply val_inj. by simpl. 
+        } rewrite H10. by rewrite !mxE.
+      } rewrite H9 in H7.
+      specialize (H7 (R_dot_prod_rel_abs_holds    n.+1 i (A2_J A)
+                    (\col_j X_m_jacobi k x0 b A j ord0))).
+      rewrite -H9 in H7. rewrite -H8 in H7. clear H8 H9.
+      specialize (H7 H2). 
+      eapply Rle_lt_trans. apply Rmult_le_compat_l. apply Rabs_pos.
+      apply Rplus_le_compat_l.
+      apply Rle_trans with 
+      ((1 + g ty n.+1) * 
+        Rabs  (\sum_j
+                  Rabs (FT2R (A2_J A (inord i) j)) *
+                  Rabs (FT2R (X_m_jacobi k x0 b A j ord0))) + 
+        g1 ty n.+1 (n.+1 - 1)%coq_nat)%Re.
+      * apply Rle_trans with 
+        (Rabs ( \sum_j
+                  (FT2R (A2_J A (inord i) j) *
+                   FT2R(X_m_jacobi k x0 b A j ord0)))  +
+          (g ty n.+1 *
+              Rabs
+                (\sum_j
+                    Rabs
+                      (FT2R (A2_J A (inord i) j)) *
+                    Rabs
+                      (FT2R
+                         (X_m_jacobi k x0 b A j
+                            ord0))) +
+              g1 ty n.+1 (n.+1 - 1)%coq_nat))%Re.
+        rewrite Rplus_comm.
+        apply Rcomplements.Rle_minus_l.
+        eapply Rle_trans. apply Rabs_triang_inv.
+        apply H7. rewrite -Rplus_assoc. apply Rplus_le_compat_r.
+        rewrite Rmult_plus_distr_r. apply Rplus_le_compat_r.
+        rewrite Rmult_1_l. rewrite Rabs_sum_in.
+        rewrite sum_abs_eq ; last by (intros; apply Rabs_pos).
+        apply /RleP. apply Rabs_ineq.
+      * apply Rle_refl.
+      * rewrite  Rabs_sum_in.
+        rewrite sum_abs_eq ; last by (intros; apply Rabs_pos).
+        (** This gives us information about conditions in terms of 
+            conditions on input
+        **)
+        eapply Rle_lt_trans. apply Rmult_le_compat_l.
+        apply Rabs_pos. rewrite -Rplus_assoc.
+        apply Rplus_le_compat_r. apply Rplus_le_compat_l.
+        apply Rmult_le_compat_l.
+        apply Rplus_le_le_0_compat; try nra; try apply g_pos.
+        apply Rle_trans with 
+            ((vec_inf_norm
+                 (x_fix x (FT2R_mat b) (FT2R_mat A)) +
+                     rho ^ k * f_error 0 b x0 x A +
+                     (1 - rho ^ k) / (1 - rho) * d_mag) * 
+              \sum_j (Rabs ( FT2R (A2_J A (inord i) j))))%Re.
+            ++ apply /RleP. rewrite RmultE.
+               rewrite big_distrr /=.
+               apply big_sum_ge_ex_abstract.
+               intros. rewrite -RmultE.
+               rewrite Rabs_mult. rewrite Rmult_comm.
+               apply Rmult_le_compat_r. apply Rabs_pos.
+               admit. (* apply x_k_bound. apply IHk. *)
+            ++ apply Rle_refl.
+            ++ admit. (* by apply bound_5. *)
+   - by apply Bminus_bplus_opp_implies .
+ }
+
+Admitted.
+
+Definition input_bound_sparse {t} {n:nat} 
+  (A: 'M[ftype t]_n.+1) (x0 b: 'cV[ftype t]_n.+1) (r : nat) :=
+  let A_real := FT2R_mat A in
+  let b_real := FT2R_mat b in
+  let x:= A_real^-1 *m b_real in
+  let rho := rho_def_sparse A b r in 
+  let d_mag := d_mag_def_sparse A b r in
+  (forall i,
+    (Rabs (FT2R (A i i)) *
+     (1 * (1 + rho) *
+      (f_error 0 b x0 x A -
+       d_mag * / (1 - rho)) +
+      2 * d_mag * / (1 - rho) +
+      2 *
+      vec_inf_norm
+        (x_fix x (FT2R_mat b) (FT2R_mat A))) <
+     (sqrt (fun_bnd t r.+1) - default_abs t) /
+     (1 + default_rel t) /
+     (1 + default_rel t))%Re) /\ 
+  (vec_inf_norm
+   (x_fix x (FT2R_mat b) (FT2R_mat A)) +
+       1 *
+       f_error 0 b x0 x A +
+       1 / (1 - rho) *
+       d_mag < sqrt (fun_bnd t r.+1))%Re /\
+  (forall i j, 
+      (Rabs (FT2R (A2_J A i j )) <
+        sqrt (fun_bnd t r.+1))%Re) /\
+  (forall i,
+     (Rabs (FT2R (b i ord0)) +
+     (1 + g t r.+1) *
+     ((vec_inf_norm
+         (x_fix x (FT2R_mat b) (FT2R_mat A)) +
+       1 * f_error 0 b x0 x A +
+       1 / (1 - rho) * d_mag) *
+      (\sum_j
+          Rabs (FT2R (A2_J A i j)))) +
+     g1 t r.+1 (r.+1 - 1)%coq_nat <
+     (bpow Zaux.radix2 (femax t) -
+      default_abs t) / (1 + default_rel t))%Re) /\
+  (forall i,
+    (Rabs (FT2R (A1_inv_J A (inord i) ord0)) *
+     (Rabs (FT2R (b (inord i) ord0)) +
+      (1 + g t r.+1) *
+      ((vec_inf_norm
+          (x_fix x (FT2R_mat b) (FT2R_mat A)) +
+        1 * f_error 0 b x0 x A +
+        1 / (1 - rho) * d_mag) *
+       (\sum_j
+           Rabs (FT2R (A2_J A (inord i) j)))) +
+      g1 t r.+1 (r.+1 - 1)%coq_nat) <
+     (bpow Zaux.radix2 (femax t) -
+      default_abs t) / (1 + default_rel t) /
+     (1 + default_rel t))%Re) /\
+  (1 * (1 + rho) *
+     ((f_error 0 b x0 x A) - d_mag * / (1 - rho)) +
+     2 * d_mag * / (1 - rho) +
+     2 *
+     vec_inf_norm
+       (x_fix x (FT2R_mat b) (FT2R_mat A)) <
+     (bpow Zaux.radix2 (femax t) -
+      default_abs t) / (1 + default_rel t))%Re.

--- a/fma_matrix_vec_mult.v
+++ b/fma_matrix_vec_mult.v
@@ -46,6 +46,15 @@ Definition e_i {n:nat} {ty} (i : 'I_n.+1)
   let rs:= sum_fold prods in
   (g ty (length l1) * Rabs rs  + g1 ty (length l1) (length l1 - 1))%Re.
 
+Lemma e_i_pos {n ty} (i : 'I_n.+1) (A : 'M[ftype ty]_n.+1) (v : 'cV[ftype ty]_n.+1) :
+  0 <= e_i i A v.
+Proof.
+  rewrite /e_i. apply Rplus_le_le_0_compat.
+  + apply Rmult_le_pos; [apply g_pos | apply Rabs_pos].
+  + apply g1_pos.
+Qed.
+
+
 Definition extract_elements {T} (idx : seq.seq nat) (l : list T) (default : T) :=
   map (fun i => nth i l default) idx.
 
@@ -322,52 +331,51 @@ Lemma matrix_vec_mult_bound {n:nat} {ty}:
   vec_inf_norm (FT2R_mat (A *f v) - (FT2R_mat A) *m (FT2R_mat v)) <=
   mat_vec_mult_err_bnd A v.
 Proof.
-intros. unfold vec_inf_norm, mat_vec_mult_err_bnd.
-apply lemmas.bigmax_le; first by rewrite size_map size_enum_ord.
-intros. rewrite seq_equiv. 
-rewrite nth_mkseq; last by rewrite size_map size_enum_ord in H1.
-pose proof (fma_dotprod_forward_error _ ty 
-            (vec_to_list_float n.+1 (\row_j A (inord i) j)^T)
-             (vec_to_list_float n.+1 v)).
-rewrite !length_veclist in H2.
-assert (n.+1 = n.+1). { lia. } 
-specialize (H2 H3).
-apply Rle_trans with (e_i (@inord n i) A v).
-+ unfold e_i. rewrite !mxE -RminusE.
-  rewrite !length_veclist.
-  apply H2.
-  assert (v = \col_j v j ord0).
-  {  apply matrixP.  unfold eqrel. intros. rewrite !mxE /=.
-      assert ( y = ord0). { apply ord1. } by rewrite H4.
-  } rewrite -H4.
-  - apply fma_dot_prod_rel_holds .
-  - pose proof (@R_dot_prod_rel_holds n ty n.+1 i (leqnn n.+1)).
-    specialize (H4 A v).
-    assert (\sum_(j < n.+1)
-               FT2R_mat A (inord i)
-                 (widen_ord (leqnn n.+1) j) *
-               FT2R_mat v
-                 (widen_ord (leqnn n.+1) j) ord0 = 
-            \sum_j
-               FT2R_mat A (inord i) j * FT2R_mat v j ord0).
-    { apply eq_big. by []. intros.
+  intros. rewrite /vec_inf_norm /mat_vec_mult_err_bnd.
+  apply bigmax_le_0head.
+  { rewrite size_map size_enum_ord; auto. } 
+  2:{ intros. move /mapP in H1. destruct H1 as [x0 H1 H2].
+      rewrite H2. apply /RleP. apply Rabs_pos. } 
+  intros. rewrite (@nth_map _ ord0).
+  2:{ rewrite size_enum_ord. rewrite size_map size_enum_ord in H1. auto. } 
+  rewrite enum_inord.
+  2:{ rewrite size_map size_enum_ord in H1. auto. }  
+  assert (H99: length (vec_to_list_float n.+1 (\row_j A (inord i) j)^T) = 
+    length (vec_to_list_float n.+1 v))
+    by rewrite !length_veclist //= .
+  pose proof (fma_dotprod_forward_error _ ty (vec_to_list_float n.+1 (\row_j A (inord i) j)^T)
+    (vec_to_list_float n.+1 v) H99). clear H99.
+  apply Rle_trans with (e_i (inord i) A v).
+  2:{ remember ([seq e_i i0 A v | i0 <- enum 'I_n.+1]) as eis.
+    assert (\big[Order.Def.max/0%Re]_(i0 <- enum 'I_n.+1)  e_i i0 A v = 
+      \big[Order.Def.max/0%Re]_(i0 <- enum 'I_(size eis)) seq.nth 0%Re eis i0).
+    { rewrite Heqeis //= size_map. rewrite size_enum_ord. apply eq_big; auto.
+      intros. rewrite (@nth_map 'I_n.+1 ord0) //=. rewrite nth_ord_enum //=.
+      rewrite size_enum_ord. apply leq_ord. } 
+    rewrite {}H3. rewrite -bigmax_seq_enum_eq. apply bigmax_ler_0head.
+    + rewrite Heqeis. apply (@map_f _ _ (fun i => (e_i i A v))). apply mem_enum.
+    + rewrite Heqeis. intros. move /mapP in H3. destruct H3 as [i0 H3 H4]. rewrite H4.
+      apply /RleP. apply e_i_pos. }
+  rewrite mxE mxE mxE mxE //=. apply H2; clear H2.
+  + pose proof (@fma_dot_prod_rel_holds n ty n.+1 i A v).
+    remember (vec_to_list_float n.+1 (\row_j A (inord i) j)^T) as l1.
+    remember (vec_to_list_float n.+1 v) as l2. simpl in H2.
+    assert (((\row_j A (inord i) j)^T (inord n) ord0 :: vec_to_list_float n (\row_j A (inord i) j)^T) = l1).
+    { rewrite Heql1. rewrite /vec_to_list_float //=. } rewrite {}H3.
+    assert (\col_j v j ord0 = v).
+    { apply matrixP. unfold eqrel. intros. rewrite !mxE /=.
+      assert (y = ord0). { apply ord1. } by rewrite H3. } rewrite {}H3.
+    assert ((v (inord n) ord0 :: vec_to_list_float n v) = l2).
+    { rewrite Heql2. rewrite /vec_to_list_float //=. } rewrite {}H3 //=.
+  + pose proof (@R_dot_prod_rel_holds n ty n.+1 i (leqnn n.+1) A v).
+    assert ((\sum_(j < n.+1)  FT2R_mat A (inord i) (widen_ord (leqnn n.+1) j) * FT2R_mat v (widen_ord (leqnn n.+1) j) ord0) =
+      (FT2R_mat A *m FT2R_mat v) (inord i) ord0).
+    { rewrite !mxE //=. apply eq_big; auto. intros. 
       assert (widen_ord (leqnn n.+1) i0 = i0).
-      { unfold widen_ord. apply val_inj. by simpl. }
-      by rewrite H6.
-    } by rewrite -H5. 
-  - apply R_dot_prod_rel_abs_holds.
-  - intros. specialize (H0 (@inord n i)). 
-    rewrite inord_val in H0. apply H0. 
-+ assert (e_i (inord i) A v = 
-         [seq e_i i0 A v | i0 <- enum 'I_n.+1]`_i).
-  { rewrite seq_equiv nth_mkseq. nra. by rewrite size_map size_enum_ord in H1. } 
-  rewrite H4. apply /RleP.
-  pose proof (@le_bigmax _ _ _ 0%Re (fun i => e_i i A v)) (inord i).
-  replace ([seq e_i i0 A v | i0 <- enum 'I_n.+1]`_i) with (e_i (inord i) A v) by auto.
-  simpl in H5. rewrite big_enum . simpl. 
-  (* apply (@bigmaxr_ler _  _ [seq e_i i0 A v | i0 <- enum 'I_n.+1] i).
-  rewrite size_map size_enum_ord.
-  by rewrite size_map size_enum_ord in H1. *)
+      { unfold widen_ord. apply val_inj. by simpl. } by rewrite H4. } 
+    by rewrite {}H3 in H2. 
+  + apply @R_dot_prod_rel_abs_holds.
+  + intros. specialize (H0 (@inord n i)). rewrite inord_val in H0. apply H0.
 Qed.
 
 Lemma bcmp_zero {ty} (x : ftype ty) :
@@ -827,7 +835,7 @@ Proof.
     specialize (H0 (y, x) H2). auto. destruct H0. auto.
 Qed.
 
-Lemma matrix_vec_mult_bound_sparse {n : nat} {ty}:
+(* Lemma matrix_vec_mult_bound_sparse {n : nat} {ty}:
   forall (A: 'M[ftype ty]_n.+1) (v : 'cV[ftype ty]_n.+1)
   {r : nat} {HA : is_r_sparse_mat A r},
   (forall (xy : ftype ty * ftype ty) (i : nat),
@@ -921,7 +929,7 @@ Proof.
     simpl in H8.
     replace ([seq e_i_sparse i0 v HA | i0 <- enum 'I_n.+1]`_i) with (e_i_sparse (inord i) v HA) by auto.
     rewrite big_enum //.
-Qed.
+Qed. *)
 
 Definition FT2R_abs {m n: nat} (A : 'M[R]_(m.+1, n.+1)) :=
   \matrix_(i,j) Rabs (A i j).
@@ -984,6 +992,23 @@ induction m.
   } rewrite -H1. by rewrite IHm.
 Qed.
 
+Lemma e_i_eq_form {n : nat} {ty} 
+  (A : 'M[ftype ty]_n.+1) (v : 'cV[ftype ty]_n.+1) (i : 'I_n.+1):
+  e_i i A v = 
+  g ty n.+1 * (Rabs ((FT2R_abs (FT2R_mat A) *m FT2R_abs (FT2R_mat v)) i ord0) ) +
+  g1 ty n.+1 (n.+1 - 1).
+Proof.
+  unfold e_i. rewrite !length_veclist.
+  rewrite -!RplusE -!RmultE. apply Rplus_eq_compat_r.
+  apply Rmult_eq_compat_l. f_equal. 
+  pose proof (@sum_fold_mathcomp_equiv n ty n.+1 i (leqnn n.+1) A v).
+  rewrite inord_val in H. rewrite -H.
+  rewrite !mxE //=. apply eq_big; auto.
+  intros. 
+  assert (widen_ord (leqnn n.+1) i0 = i0).
+  { unfold widen_ord. apply val_inj. by simpl. } 
+  by rewrite {}H1.
+Qed.
 
 
 Lemma matrix_err_bound_equiv {n:nat} {ty}
@@ -992,79 +1017,47 @@ Lemma matrix_err_bound_equiv {n:nat} {ty}
  vec_inf_norm (FT2R_abs (FT2R_mat A) *m FT2R_abs (FT2R_mat v)) * g ty n.+1 +
    g1 ty n.+1 (n.+1 - 1).
 Proof.
-unfold mat_vec_mult_err_bnd.
-unfold vec_inf_norm. rewrite mulrC.
-rewrite -bigmaxr_mulr.
-+ apply bigmaxrP . split.
-  - rewrite -bigmaxr_addr.
-    assert ([seq y + g1 ty n.+1 (n.+1 - 1)
-               | y <- [seq g ty n.+1 *
-                           Rabs
-                             ((FT2R_abs (FT2R_mat A) *m 
-                               FT2R_abs (FT2R_mat v)) i ord0)
-                         | i <- enum 'I_n.+1]] = 
-            [seq e_i i A v | i <- enum 'I_n.+1]).
-    { rewrite seq_equiv. rewrite -map_comp.
-      rewrite seq_equiv. apply eq_mkseq.
-      unfold eqfun. intros.
-      rewrite !mxE. unfold e_i.
-      rewrite !length_veclist.
-      pose proof (@sum_fold_mathcomp_equiv n ty n.+1 x (leqnn n.+1) A v).
-      rewrite -H.
-      assert (\sum_j
-                  FT2R_abs (FT2R_mat A) (inord x) j *
-                  FT2R_abs (FT2R_mat v) j ord0 = 
-              \sum_(j < n.+1)
-                 FT2R_abs (FT2R_mat A) (inord x)
-                   (widen_ord (leqnn n.+1) j) *
-                 FT2R_abs (FT2R_mat v)
-                   (widen_ord (leqnn n.+1) j) ord0).
-      { apply eq_big. by []. intros.
-        assert (widen_ord (leqnn n.+1) i = i).
-        { unfold widen_ord. apply val_inj. by simpl. }
-        by rewrite H1.
-      } by rewrite -H0.
-    } rewrite H. apply bigmaxr_mem.
-    by rewrite size_map size_enum_ord.
-  - intros. rewrite seq_equiv. rewrite nth_mkseq;
-    last by rewrite size_map size_enum_ord in H.
-    unfold e_i. rewrite !length_veclist.
-    apply /RleP. rewrite -RplusE.
-    apply Rplus_le_compat_r.
-    apply Rle_trans with 
-    ([seq (g ty n.+1 *
-         Rabs
-           ((FT2R_abs (FT2R_mat A) *m 
-             FT2R_abs (FT2R_mat v)) i0 ord0))%Ri
-      | i0 <- enum 'I_n.+1]`_i).
-    * rewrite seq_equiv. rewrite nth_mkseq;
-      last by rewrite size_map size_enum_ord in H.
-      rewrite -RmultE. rewrite !mxE.
-      pose proof (@sum_fold_mathcomp_equiv n ty n.+1 i (leqnn n.+1) A v).
-      rewrite -H0.
-      assert (\sum_j
-                  FT2R_abs (FT2R_mat A) (inord i) j *
-                  FT2R_abs (FT2R_mat v) j ord0 = 
-              \sum_(j < n.+1)
-                 FT2R_abs (FT2R_mat A) (inord i)
-                   (widen_ord (leqnn n.+1) j) *
-                 FT2R_abs (FT2R_mat v)
-                   (widen_ord (leqnn n.+1) j) ord0).
-      { apply eq_big. by []. intros.
-        assert (widen_ord (leqnn n.+1) i0 = i0).
-        { unfold widen_ord. apply val_inj. by simpl. }
-        by rewrite H2.
-      } rewrite -H1. apply Rle_refl.
-   * apply /RleP.
-     apply (@bigmaxr_ler _ 0%Re [seq (g ty n.+1 *
-                 Rabs
-                   ((FT2R_abs (FT2R_mat A) *m 
-                     FT2R_abs (FT2R_mat v)) i0 ord0))%Ri
-              | i0 <- enum 'I_n.+1] i).
-     rewrite size_map size_enum_ord.
-     by rewrite size_map size_enum_ord in H.
-+ apply /RleP. apply g_pos.
+  rewrite /mat_vec_mult_err_bnd /vec_inf_norm mulrC.
+  rewrite -RmultE bigmax_mulr_0head.
+  2:{ rewrite size_map size_enum_ord. auto. } 
+  2:{ intros. move /mapP in H. destruct H as [i H1 H2]. rewrite H2. apply /RleP. apply Rabs_pos. }
+  2:{ apply /RleP. apply g_pos. } 
+  assert (\big[Order.Def.max/0%Re]_(i <- enum 'I_n.+1)  e_i i A v = 
+    \big[Order.Def.max/0%Re]_(i <- [seq e_i i A v | i <- enum 'I_n.+1]) i).
+  { rewrite big_map_id. auto.  } rewrite {}H.
+  apply bigmaxP_0head.
+  + rewrite size_map size_enum_ord. auto.
+  + intros. rewrite (@nth_map _ ord0 _ 0%Re (fun (i0 : 'I_n.+1) => e_i i0 A v) i).
+    2:{ by rewrite size_map in H. } 
+    assert (e_i (seq.nth ord0 (enum 'I_n.+1) i) A v = e_i (inord i) A v).
+    { rewrite enum_inord; auto. 
+      rewrite size_map size_enum_ord in H. auto. }  rewrite {}H0.
+    rewrite e_i_eq_form. rewrite -!RplusE. apply Rplus_le_compat_r.
+    apply bigmax_ler_0head.
+    2:{ intros. move /mapP in H0. destruct H0 as [x0 H0 H1]. rewrite H1. 
+      apply /RleP. apply Rmult_le_pos. apply g_pos. 
+      move /mapP in H0. destruct H0 as [x1 H0 H2]. rewrite H2. apply Rabs_pos. }
+    apply /mapP. eexists.
+    { apply /mapP. exists (inord i). apply mem_enum. reflexivity. } 
+    reflexivity.
+  + intros. move /mapP in H. destruct H as [i H1 H2]. rewrite H2. apply /RleP. apply e_i_pos.
+  + rewrite -bigmax_addc_0head.
+    2:{ rewrite size_map size_map size_enum_ord //=. } 
+    2:{ apply /RleP. apply g1_pos. }
+    2:{ intros. move /mapP in H. destruct H as [i H1 H2]. rewrite H2. apply /RleP.
+      rewrite -RmultE. apply Rmult_le_pos. apply g_pos.
+      move /mapP in H1. destruct H1 as [i0 H1 H3]. rewrite H3. apply Rabs_pos. }
+    assert (\big[Order.Def.max/0%Re]_(i <- [seq g ty n.+1 * x  | x <- [seq Rabs ((FT2R_abs (FT2R_mat A) *m FT2R_abs (FT2R_mat v)) i ord0)  | i <- enum 'I_n.+1]])  (i + g1 ty n.+1 (n.+1 - 1)) =
+      \big[Order.Def.max/0%Re]_(i <- [seq e_i i A v | i <- enum 'I_n.+1]) i).
+    { rewrite [LHS]bigmax_seq_map_eq. apply bigmax_same_lr.
+      rewrite -map_comp -map_comp. apply map_ext.
+      intros. rewrite //= e_i_eq_form //=. }
+    rewrite {}H. apply bigmax_mem_0head.
+    - rewrite size_map size_enum_ord //=.
+    - intros. move /mapP in H. destruct H as [i H1 H2]. rewrite H2. apply /RleP.
+      apply e_i_pos.
 Qed.
+
 
 
 Lemma matrix_err_bound_le_rel {n:nat} {ty}
@@ -1073,6 +1066,10 @@ Lemma matrix_err_bound_le_rel {n:nat} {ty}
  (matrix_inf_norm (FT2R_mat A) * vec_inf_norm (FT2R_mat v)) * g ty n.+1 +
    g1 ty n.+1 (n.+1 - 1).
 Proof.
+  
+
+
+
 change
 (mat_vec_mult_err_bnd A v <=
 (matrix_inf_norm (FT2R_mat A) * vec_inf_norm (FT2R_mat v) * g ty n.+1 +

--- a/fma_real_func_model.v
+++ b/fma_real_func_model.v
@@ -113,58 +113,45 @@ Lemma vec_inf_norm_diag_matrix_vec_mult_R {n:nat} (v1 v2 : 'cV[R]_n.+1):
   vec_inf_norm (diag_matrix_vec_mult_R v1 v2) <= 
   vec_inf_norm v1 * vec_inf_norm v2.
 Proof.
-unfold vec_inf_norm, diag_matrix_vec_mult_R.
-rewrite -bigmaxr_mulr.
-+ apply /RleP. apply lemmas.bigmax_le.
-  - by rewrite size_map size_enum_ord.
-  - intros. rewrite seq_equiv. rewrite nth_mkseq; 
-    last by rewrite size_map size_enum_ord in H.
-    apply Rle_trans with 
-    [seq (bigmaxr 0%Re
-           [seq Rabs (v1 i1 0) | i1 <- enum 'I_n.+1] *
-         Rabs (v2 i0 0))%Ri
-      | i0 <- enum 'I_n.+1]`_i.
-    * assert ([seq bigmaxr 0%Re
-                    [seq Rabs (v1 i1 0) | i1 <- enum 'I_n.+1] *
-                  Rabs (v2 i0 0)
-                | i0 <- enum 'I_n.+1] = 
-               mkseq (fun i: nat => bigmaxr 0%Re
-                            [seq Rabs (v1 i1 0) | i1 <- enum 'I_n.+1] *
-                            Rabs (v2 (@inord n i) 0))
-                             n.+1).
-      { by rewrite !seq_equiv. } rewrite H0.
-      rewrite nth_mkseq; 
-      last by rewrite size_map size_enum_ord in H.
-      rewrite !mxE. rewrite -!RmultE. rewrite Rabs_mult.
-      rewrite !nth_vec_to_list_real; try rewrite inord_val.
-      ++ apply Rmult_le_compat_r; try apply Rabs_pos.
-         apply Rle_trans with 
-         [seq Rabs (v1 i1 0) | i1 <- enum 'I_n.+1]`_i.
-         -- rewrite seq_equiv. rewrite nth_mkseq; 
-            last by rewrite size_map size_enum_ord in H.
-            apply Rle_refl.
-         -- apply /RleP.
-            apply (@bigmaxr_ler _ 0%Re [seq Rabs (v1 i1 0) | i1 <- enum 'I_n.+1] i).
-            rewrite size_map size_enum_ord.
-            by rewrite size_map size_enum_ord in H.
-      ++ by rewrite size_map size_enum_ord in H.
-      ++ by rewrite size_map size_enum_ord in H.
-    * apply /RleP.
-      apply (@bigmaxr_ler _ 0%Re [seq bigmaxr 0%Re
-                     [seq Rabs (v1 i1 0) | i1 <- enum 'I_n.+1] *
-                   Rabs (v2 i0 0)
-                 | i0 <- enum 'I_n.+1] i).
-       rewrite size_map size_enum_ord.
-       by rewrite size_map size_enum_ord in H.
-+ apply bigmax_le_0.
-  - apply /RleP. apply Rle_refl.
-  - intros. rewrite seq_equiv. rewrite nth_mkseq;
-    last by rewrite size_map size_enum_ord in H.
-    apply /RleP. apply Rabs_pos.
+  rewrite /vec_inf_norm /diag_matrix_vec_mult_R.
+  remember (\big[maxr/0%Re]_(i <- [seq Rabs (v1 i 0)  | i <- enum 'I_n.+1])  i) as v1norm.
+  rewrite -RmultE. rewrite bigmax_mulr_0head.
+  2:{ rewrite size_map size_enum_ord //=. } 
+  2:{ intros. move /mapP in H. destruct H as [ix H1 H2]. rewrite H2.
+      apply /RleP. apply Rabs_pos. } 
+  2:{ rewrite Heqv1norm. pose proof (vec_inf_norm_nonneg v1). apply H. } 
+  apply /RleP. apply bigmax_le_0head.
+  { rewrite size_map size_enum_ord //=. }
+  2:{ intros. move /mapP in H. destruct H as [ix H1 H2]. rewrite H2.
+    apply /RleP. apply Rabs_pos. }
+  intros. rewrite (@nth_map _ 0).
+  2:{ rewrite size_enum_ord. rewrite size_map size_enum_ord in H. apply H. }
+  rewrite enum_inord.
+  2:{ rewrite size_map size_enum_ord in H. apply H. }
+  rewrite !mxE Rabs_mult seq_sum_mult_distrl.
+  remember (inord i) as ik.
+  apply Rle_trans with (v1norm * Rabs (nth (n.+1.-1 - ik) (vec_to_list_real n.+1 v2) 0)).
+  { apply Rmult_le_compat_r. apply Rabs_pos.
+    rewrite Heqv1norm. apply bigmax_ler_0head.
+    2:{ intros. move /mapP in H0. destruct H0 as [ix H1 H2]. rewrite H2.
+        apply /RleP. apply Rabs_pos. }
+    rewrite nth_vec_to_list_real.
+    2:{ rewrite Heqik. rewrite inordK. rewrite size_map size_enum_ord in H; auto.
+        rewrite size_map size_enum_ord in H; auto. }
+    apply /mapP. exists ik. 
+    2:{ rewrite Heqik. rewrite inordK; rewrite size_map size_enum_ord in H; auto. }
+    rewrite Heqik. apply mem_enum. }
+  apply bigmax_ler_0head.
+  2:{ intros. move /mapP in H0. destruct H0 as [ix H1 H2]. rewrite H2.
+      apply /RleP. apply Rmult_le_pos; try apply Rabs_pos.
+      rewrite Heqv1norm. pose proof (vec_inf_norm_nonneg v1). 
+      apply /RleP. auto. } 
+  apply /mapP. exists ik. apply mem_enum.
+  f_equal. f_equal. rewrite nth_vec_to_list_real. 
+  2:{ rewrite Heqik. rewrite inordK; rewrite size_map size_enum_ord in H; auto. } 
+  rewrite inord_val. auto.
 Qed.
-
-
-
+    
 Lemma x_fixpoint {n:nat} x b (A: 'M[R]_n.+1):
   A *m x = b ->
   (forall i, A i i <> 0%Re) ->

--- a/inf_norm_properties.v
+++ b/inf_norm_properties.v
@@ -35,67 +35,91 @@ Import Order.TTheory GRing.Theory Num.Def Num.Theory.
 (** Infinity norm of a vector is the maximum of 
     absolute values of the entries of a vector 
 **)
-Definition vec_inf_norm {n:nat} (v : 'cV[R]_n) :=
- bigmaxr 0%Re [seq (Rabs (v i 0)) | i <- enum 'I_n].
+
+Definition vec_inf_norm {n : nat} (v : 'cV[R]_n) :=
+  let s := [seq (Rabs (v i 0)) | i <- enum 'I_n] in 
+  \big[maxr / 0%Re]_(i <- s) i.
+
+(* bigmaxr deprecated*)
+(* Definition vec_inf_norm {n:nat} (v : 'cV[R]_n) :=
+ bigmaxr 0%Re [seq (Rabs (v i 0)) | i <- enum 'I_n]. *)
 
 (** Infinity norm of a matrix is the maximum of the columm sums **)
-Definition matrix_inf_norm {n:nat} (A: 'M[R]_n) :=
-  bigmaxr 0%Re [seq (row_sum A i) | i <- enum 'I_n].
+Definition matrix_inf_norm {n : nat} (A : 'M[R]_n) :=
+  let s := [seq (row_sum A i) | i <- enum 'I_n] in 
+  \big[maxr / 0%Re]_(i <- s) i.
+
+(* bigmaxr deprecated *)
+(* Definition matrix_inf_norm {n:nat} (A: 'M[R]_n) :=
+  bigmaxr 0%Re [seq (row_sum A i) | i <- enum 'I_n]. *)
+
+Lemma vec_inf_norm_nonneg {n : nat} (v : 'cV[R]_n.+1):
+  0 <= vec_inf_norm v.
+Proof.
+  rewrite /vec_inf_norm. 
+  apply bigmax_le_0_0head. intros.
+  rewrite (@nth_map _ 0).
+  + apply /RleP. apply Rabs_pos.
+  + rewrite size_map in H. auto.
+Qed.
+
+Lemma matrix_inf_norm_nonneg {n : nat} (A : 'M[R]_n.+1):
+  0 <= matrix_inf_norm A.
+Proof.
+  rewrite /matrix_inf_norm.
+  apply bigmax_le_0_0head. intros.
+  rewrite (@nth_map _ 0).
+  + rewrite /row_sum. apply sum_of_pos. intros.
+    apply /RleP. apply Rabs_pos.
+  + rewrite size_map in H. auto.
+Qed.
+
 
 Lemma vec_inf_norm_0_is_0 {n:nat}: 
   @vec_inf_norm n.+1 0 = 0%Re.
 Proof.
-rewrite /vec_inf_norm. apply bigmaxrP.
-split.
-+ apply /mapP. exists (@ord0 n).
-  - by rewrite mem_enum.
-  - by rewrite mxE Rabs_R0.
-+ intros. rewrite nth_seq_0_is_0. apply /RleP. apply Rle_refl.
-  by rewrite size_map size_enum_ord in H. 
+  rewrite /vec_inf_norm.
+  (* rewrite seq_equiv /mkseq. *)
+  assert ([seq Rabs ((GRing.zero : 'cV[R]_n.+1) (i : 'I_n.+1) 0) | i <- enum 'I_n.+1] = 
+    [seq 0%Re | i <- enum 'I_n.+1]).
+  { apply eq_map. intros i. rewrite zero_vec_entry Rabs_R0 //=. } 
+  assert ([seq 0%Re | _ <- enum 'I_n.+1] = nseq n.+1 0%Re). 
+  { apply seq_const_nseq. by rewrite size_enum_ord. } 
+  rewrite H H0 big_nseq.
+  clear H H0. induction n as [|n'].
+  + rewrite //=. unfold maxr. replace (0%Re < 0%Re) with false by auto. by [].
+  + rewrite //=. rewrite //= in IHn'. rewrite IHn'.
+    rewrite /maxr. replace (0%Re < 0%Re) with false by auto. by [].
 Qed.
 
 
-
 Lemma triang_ineq {n:nat} : forall a b: 'cV[R]_n.+1,
-vec_inf_norm(a + b) <= vec_inf_norm a + vec_inf_norm b.
+  vec_inf_norm(a + b) <= vec_inf_norm a + vec_inf_norm b.
 Proof.
-intros.
-rewrite /vec_inf_norm. apply /RleP.
-apply lemmas.bigmax_le.
-+ by rewrite size_map size_enum_ord. 
-+ intros. rewrite -RplusE. 
-  apply Rle_trans with 
-    ([seq Rabs (a i0 0) | i0 <- enum 'I_n.+1]`_i + 
-     [seq Rabs (b i0 0) | i0 <- enum 'I_n.+1]`_i)%Re.
-  - assert ([seq Rabs ((a + b)%Ri i0 0) | i0 <- enum 'I_n.+1] = 
-               mkseq (fun i =>  Rabs ((a + b)%Ri (@inord n i) 0)) n.+1).
-    { unfold mkseq. rewrite -val_enum_ord.
-      rewrite -[in RHS]map_comp.
-      apply eq_map. unfold eqfun. intros.
-      rewrite !mxE //=. rewrite !mxE. by rewrite inord_val.
-    } rewrite H0 nth_mkseq; last by rewrite size_map size_enum_ord in H.  
-    assert ([seq Rabs (a i0 0) | i0 <- enum 'I_n.+1] = 
-               mkseq (fun i =>  Rabs (a (@inord n i) 0)) n.+1).
-    { unfold mkseq. rewrite -val_enum_ord.
-      rewrite -[in RHS]map_comp.
-      apply eq_map. unfold eqfun. intros. by rewrite //= inord_val //=.
-    } rewrite H1 nth_mkseq ; last by rewrite size_map size_enum_ord in H.
-    assert ([seq Rabs (b i0 0) | i0 <- enum 'I_n.+1] = 
-               mkseq (fun i =>  Rabs (b (@inord n i) 0)) n.+1).
-    { unfold mkseq. rewrite -val_enum_ord.
-      rewrite -[in RHS]map_comp.
-      apply eq_map. unfold eqfun. intros. by rewrite //= inord_val //=.
-    } rewrite H2 nth_mkseq ; last by rewrite size_map size_enum_ord in H.
-    rewrite !mxE //=. rewrite -RplusE. apply Rabs_triang.
-  - apply Rplus_le_compat.
-    * apply /RleP. 
-      apply (@bigmaxr_ler _ 0%Re [seq Rabs (a i0 0) | i0 <- enum 'I_n.+1] i).
-      rewrite size_map size_enum_ord.
-      by rewrite size_map size_enum_ord in H.
-    * apply /RleP. 
-      apply (@bigmaxr_ler _ 0%Re [seq Rabs (b i0 0) | i0 <- enum 'I_n.+1] i).
-      rewrite size_map size_enum_ord.
-      by rewrite size_map size_enum_ord in H.
+  intros. rewrite /vec_inf_norm. apply /RleP. apply bigmax_le_0head.
+  + rewrite size_map size_enum_ord //=.
+  + intros. rewrite size_map size_enum_ord in H. 
+    assert (nth 0 [seq Rabs ((a + b)%Ri i0 0)  | i0 <- enum 'I_n.+1] i = 
+            Rabs ((a + b)%Ri (@inord n i) 0)).
+    { rewrite seq_equiv. rewrite nth_mkseq; auto. }
+    rewrite H0.
+    apply Rle_trans with (Rabs (a (@inord n i) ord0) + Rabs (b (@inord n i) ord0))%Re.
+    { rewrite !mxE //=. rewrite -!RplusE. apply Rabs_triang. }
+    rewrite -!RplusE. apply Rplus_le_compat.
+    - apply bigmax_ler_0head.
+      { rewrite seq_equiv /mkseq. 
+        apply (@map_f _ _ (fun i => Rabs (a (inord i) ord0)) (iota 0 n.+1) i).
+        rewrite mem_iota. rewrite //=. }
+      { intros. move /mapP in H1. destruct H1 as [ix H1 H2]. rewrite H2.
+        apply /RleP. apply Rabs_pos. }
+    - apply bigmax_ler_0head.
+      { rewrite seq_equiv /mkseq. 
+        apply (@map_f _ _ (fun i => Rabs (b (inord i) ord0)) (iota 0 n.+1) i).
+        rewrite mem_iota. rewrite //=. }
+      { intros. move /mapP in H1. destruct H1 as [ix H1 H2]. rewrite H2.
+        apply /RleP. apply Rabs_pos. }
+  + intros. move /mapP in H. destruct H as [ix H1 H2]. rewrite H2.
+    apply /RleP. apply Rabs_pos.
 Qed.
 
 
@@ -104,80 +128,50 @@ Lemma submult_prop {n:nat} (A: 'M[R]_n.+1) (v : 'cV[R]_n.+1):
   vec_inf_norm (A *m v) <=
   matrix_inf_norm A * vec_inf_norm v.
 Proof.
-rewrite /vec_inf_norm /matrix_inf_norm. rewrite mulrC.
-rewrite -bigmaxr_mulr.
-+ apply /RleP. apply lemmas.bigmax_le.
-  - by rewrite size_map size_enum_ord.
-  - intros.
-    apply Rle_trans with
-    [seq (bigmaxr 0
-           [seq Rabs (v i1 0) | i1 <- enum 'I_n.+1] *
-         row_sum A i0)%Ri
-      | i0 <- enum 'I_n.+1]`_i.
-    * assert ([seq Rabs ((A *m v) i0 0) | i0 <- enum 'I_n.+1] = 
-              mkseq (fun i => Rabs ((A *m v) (@inord n i) 0)) n.+1).
-      { unfold mkseq. rewrite -val_enum_ord.
-        rewrite -[in RHS]map_comp.
-        apply eq_map. unfold eqfun. intros.
-        rewrite !mxE //=. rewrite !mxE. by rewrite //= inord_val //=.
-      } rewrite H0 nth_mkseq ; last by rewrite size_map size_enum_ord in H.
-      assert ([seq bigmaxr 0
-                  [seq Rabs (v i1 0) | i1 <- enum 'I_n.+1] *  row_sum A i0
-                    | i0 <- enum 'I_n.+1] = 
-               mkseq (fun i =>  bigmaxr 0  
-                        [seq Rabs (v i1 0) | i1 <- enum 'I_n.+1] *  row_sum A (@inord n i)) n.+1).
-      { unfold mkseq. rewrite -val_enum_ord.
-        rewrite -[in RHS]map_comp.
-        apply eq_map. unfold eqfun. intros.
-        by rewrite //= inord_val //=.
-      } rewrite H1 nth_mkseq ; last by rewrite size_map size_enum_ord in H.
-      rewrite -RmultE. rewrite !mxE.
-      apply Rle_trans with 
-        (\sum_j Rabs (A (inord i) j * v j 0)).
-      ++ apply /RleP. apply Rabs_ineq.
-      ++ assert (\sum_j Rabs (A (inord i) j * v j 0) = 
-                  \sum_j (Rabs (A (inord i) j) * Rabs (v j 0))).
-         { apply eq_big. by []. intros. by rewrite Rabs_mult. }
-         rewrite H2. rewrite Rmult_comm. apply /RleP. rewrite RmultE. rewrite -bigmaxr_mulr.
-         apply /RleP. 
-         rewrite bigmaxr_mulr. rewrite -RmultE. rewrite /row_sum.
-         rewrite big_distrl //=.
-         apply /RleP. apply big_sum_ge_ex_abstract. intros.
-         rewrite -!RmultE. apply Rmult_le_compat_l.
-         -- apply Rabs_pos.
-         -- apply Rle_trans with [seq Rabs (v i1 0) | i1 <- enum 'I_n.+1]`_i0.
-            ** assert ([seq Rabs (v i1 0) | i1 <- enum 'I_n.+1] = 
-                       mkseq (fun i => Rabs (v (@inord n i) 0)) n.+1).
-               { unfold mkseq. rewrite -val_enum_ord.
-                 rewrite -[in RHS]map_comp.
-                 apply eq_map. unfold eqfun. intros.
-                 by rewrite //= inord_val //=.
-               } rewrite H4 nth_mkseq ; last by rewrite size_map size_enum_ord in H. 
-               rewrite //= inord_val. nra.
-            ** apply /RleP. apply (@bigmaxr_ler _ 0%Re [seq Rabs (v i1 0) | i1 <- enum 'I_n.+1] i0).
-                rewrite size_map size_enum_ord.
-                by rewrite size_map size_enum_ord in H.
-         -- unfold row_sum. apply big_ge_0_ex_abstract. intros.
-            apply /RleP. apply Rabs_pos.
-         -- unfold row_sum. apply big_ge_0_ex_abstract. intros.
-            apply /RleP. apply Rabs_pos.
-    * apply /RleP. 
-      apply (@bigmaxr_ler _ 0%Re [seq bigmaxr 0
-                [seq Rabs (v i1 0) | i1 <- enum 'I_n.+1] * row_sum A i0
-                  | i0 <- enum 'I_n.+1] i).
-      rewrite size_map size_enum_ord.
-      by rewrite size_map size_enum_ord in H.
-+ apply bigmax_le_0.
-  - by apply /RleP; apply Rle_refl.
-  - intros. 
-    assert ([seq Rabs (v i0 0) | i0 <- enum 'I_n.+1]= 
-              mkseq (fun i => Rabs (v (@inord n i) 0)) n.+1).
-    { unfold mkseq. rewrite -val_enum_ord.
-      rewrite -[in RHS]map_comp.
-      apply eq_map. unfold eqfun. intros.
-      by rewrite //= inord_val //=.
-    } rewrite H0 nth_mkseq ; last by rewrite size_map size_enum_ord in H.
-    unfold row_sum. apply /RleP. apply Rabs_pos.
+  rewrite /vec_inf_norm /matrix_inf_norm mulrC.
+  rewrite -!RmultE.
+  rewrite bigmax_mulr_0head.
+  2:{ rewrite size_map size_enum_ord //=. } 
+  2:{ intros. move /mapP in H. destruct H as [ix H1 H2]. rewrite H2.
+      rewrite /row_sum. apply big_ge_0_ex_abstract. intros. apply /RleP. apply Rabs_pos. }
+  2:{ pose proof (vec_inf_norm_nonneg v). rewrite /vec_inf_norm in H. auto. } 
+  remember (\big[maxr/0%Re]_(i <- [seq Rabs (v i 0)  | i <- enum 'I_n.+1])  i) as vnorm.
+  apply /RleP. apply bigmax_le_0head.
+  { rewrite size_map size_enum_ord //=. } 
+  2:{ intros. move /mapP in H. destruct H as [ix H1 H2]. rewrite H2. apply /RleP. apply Rabs_pos. }
+  intros. rewrite (@nth_map _ 0).
+  2:{ rewrite size_map size_enum_ord in H. rewrite size_enum_ord. auto. }
+  rewrite enum_inord.
+  2:{ rewrite size_map size_enum_ord in H. auto. }
+  rewrite mxE. eapply Rle_trans.
+  { apply /RleP. apply Rabs_ineq. } 
+  rewrite //=. 
+  assert ([seq (vnorm * x)%Ri  | x <- [seq row_sum A i0  | i0 <- enum 'I_n.+1]] =
+    [seq vnorm * row_sum A i0  | i0 <- enum 'I_n.+1]).
+  { rewrite -map_comp //=. } rewrite {}H0.
+  assert (\sum_(j < n.+1) Rabs (A (inord i) j * v j 0) <= 
+          \sum_(j < n.+1) Rabs (A (inord i) j) * vnorm).
+  { apply sum_all_terms_le. intros. rewrite -!RmultE.
+    rewrite !Rabs_mult. apply Rmult_le_compat_l.
+    apply Rabs_pos. rewrite Heqvnorm. apply bigmax_ler_0head.
+    { apply (@map_f _ _ (fun i0 => Rabs (v i0 0)) (enum 'I_n.+1) i0).
+      apply mem_enum. }
+    intros. move /mapP in H0. destruct H0. rewrite H1. apply /RleP. apply Rabs_pos. }
+  eapply Rle_trans. { apply /RleP. apply H0. } clear H0.
+  rewrite sum_mult_distrr -!RmultE Rmult_comm.
+  assert (vnorm * (\sum_(i0 < n.+1)  Rabs (A (inord i) i0)) <=
+    vnorm * row_sum A (inord i)).
+  { rewrite /row_sum. auto. } 
+  eapply Rle_trans. { apply /RleP. apply H0. } clear H0.
+  remember (inord i) as i0.
+  apply bigmax_ler_0head.
+  { apply (@map_f _ _ (fun i0 => vnorm * row_sum A i0) (enum 'I_n.+1) i0).
+    apply mem_enum. } 
+  intros. move /mapP in H0. destruct H0. rewrite H1. apply /RleP.
+  rewrite -!RmultE. apply Rmult_le_pos.
+  + rewrite Heqvnorm. apply /RleP. apply vec_inf_norm_nonneg.
+  + rewrite /row_sum. apply /RleP. apply sum_of_pos. intros.
+    apply /RleP. apply Rabs_pos.
 Qed.
 
 
@@ -185,13 +179,7 @@ Qed.
 Lemma matrix_norm_pd {n:nat} (A : 'M[R]_n.+1):
   0 <= matrix_inf_norm A.
 Proof.
-rewrite /matrix_inf_norm.
-apply bigmax_le_0.
-+ by apply /RleP; apply Rle_refl.
-+ intros. rewrite seq_equiv.
-  rewrite nth_mkseq; last by rewrite size_map size_enum_ord in H.
-  rewrite /row_sum. apply big_ge_0_ex_abstract.
-  intros. apply /RleP. apply Rabs_pos.
+  apply matrix_inf_norm_nonneg.
 Qed.
 
 
@@ -200,17 +188,12 @@ Qed.
 Lemma vec_norm_pd {n:nat} (v : 'cV[R]_n.+1):
   0 <= vec_inf_norm v.
 Proof.
-rewrite /vec_inf_norm.
-apply bigmax_le_0.
-+ by apply /RleP; apply Rle_refl.
-+ intros. rewrite seq_equiv.
-  rewrite nth_mkseq; last by rewrite size_map size_enum_ord in H.
-  apply /RleP. apply Rabs_pos.
+  apply vec_inf_norm_nonneg.
 Qed.
 
 
-Lemma reverse_triang_ineq:
-  forall n a b c, 
+
+Lemma reverse_triang_ineq {n : nat} (a b: 'cV[R]_n.+1) (c : R):
   @vec_inf_norm n.+1 (a - b) <= c -> 
   @vec_inf_norm n.+1 (a) - @vec_inf_norm n.+1 (b) <= c.
 Proof.
@@ -265,66 +248,60 @@ Lemma matrix_norm_le {n:nat}:
   forall (A B : 'M[R]_n.+1),
   matrix_inf_norm (A *m B) <= matrix_inf_norm A * matrix_inf_norm B.
 Proof.
-intros. rewrite /matrix_inf_norm.
-apply /RleP. apply lemmas.bigmax_le.
-+ by rewrite size_map size_enum_ord.
-+ intros. rewrite seq_equiv. rewrite nth_mkseq.
-  - rewrite /row_sum. 
-    apply Rle_trans with 
-    (\sum_(j < n.+1) (\sum_(k < n.+1) (Rabs (A (inord i) k) * Rabs (B k j))%Re)).
-    * apply /RleP. apply big_sum_ge_ex_abstract. intros.
-      rewrite !mxE.
-      apply Rle_trans with 
-      (\sum_j (Rabs ((A (inord i) j) * B j i0))).
-      ++ apply /RleP. apply Rabs_ineq.
-      ++ assert (\sum_j Rabs (A (inord i) j * B j i0) = 
+  intros. rewrite /matrix_inf_norm.
+  apply /RleP. apply bigmax_le_0head.
+  { rewrite size_map size_enum_ord //=. } 
+  2:{ intros. move /mapP in H. destruct H as [ix H1 H2]. rewrite H2.
+      rewrite /row_sum. apply big_ge_0_ex_abstract. intros. apply /RleP. apply Rabs_pos. }
+  intros. rewrite (@nth_map _ 0).
+  2:{ rewrite size_map size_enum_ord in H. rewrite size_enum_ord. auto. }
+  rewrite enum_inord.
+  2:{ rewrite size_map size_enum_ord in H. auto. }
+  rewrite /row_sum.
+  apply Rle_trans with (\sum_(j < n.+1) (\sum_(k < n.+1) (Rabs (A (inord i) k) * Rabs (B k j))%Re)).
+  { apply /RleP. apply big_sum_ge_ex_abstract. intros. 
+    rewrite !mxE. apply Rle_trans with (\sum_j (Rabs ((A (inord i) j) * B j i0))).
+    { apply /RleP. apply Rabs_ineq. }
+    assert (\sum_j Rabs (A (inord i) j * B j i0) = 
                   \sum_(k < n.+1) (Rabs (A (inord i) k) * Rabs (B k i0))%Re).
-         { apply eq_big. by []. intros. by rewrite Rabs_mult. }
-         rewrite H1. nra.
-    * assert (\sum_(j < n.+1)
-                \sum_(k < n.+1)
-                   (Rabs (A (inord i) k) * Rabs (B k j))%Re = 
-               \sum_(k < n.+1)
-                  \sum_(j < n.+1)
-                     (Rabs (A (inord i) k) * Rabs (B k j))%Re).
-      { apply exchange_big. } rewrite H0. 
-      rewrite mulrC. rewrite -bigmaxr_mulr.
-      apply Rle_trans with 
-      (nth 0 [seq (bigmaxr 0 [seq \sum_(j < n.+1) Rabs (B i1 j)
-                      | i1 <- enum 'I_n.+1] *
-                    (\sum_(j < n.+1) Rabs (A i0 j)))%Ri | i0 <- enum 'I_n.+1] i).
-      ++ rewrite seq_equiv. rewrite nth_mkseq. 
-         -- rewrite big_distrr //=. apply /RleP.
-            apply big_sum_ge_ex_abstract. intros.
-            rewrite -RmultE. rewrite Rmult_comm.
-            rewrite -big_distrr //=. rewrite -RmultE.
-            apply Rmult_le_compat_l.
-            ** apply Rabs_pos.
-            ** apply /RleP. 
-               assert (\sum_(i1 < n.+1) Rabs (B i0 i1) = 
-                        nth 0 [seq \sum_(j < n.+1) Rabs (B i1 j)
-                               | i1 <- enum 'I_n.+1]  i0).
-                { rewrite seq_equiv. rewrite nth_mkseq. by rewrite inord_val. apply ltn_ord. }
-                rewrite H2. 
-                apply (@bigmaxr_ler _ 0  [seq \sum_(j < n.+1) Rabs (B i1 j)
-                                           | i1 <- enum 'I_n.+1] i0).
-                rewrite size_map size_enum_ord. apply ltn_ord.
-         -- by rewrite size_map size_enum_ord in H.
-      ++ apply /RleP. 
-         apply (@bigmaxr_ler _ 0%Re [seq bigmaxr 0
-                       [seq \sum_(j < n.+1) Rabs (B i1 j)
-                          | i1 <- enum 'I_n.+1] *
-                     (\sum_(j < n.+1) Rabs (A i0 j))
-                   | i0 <- enum 'I_n.+1] i).
-         rewrite size_map size_enum_ord.
-         by rewrite size_map size_enum_ord in H.
-      ++ apply bigmax_le_0.
-         -- apply /RleP. apply Rle_refl.
-         -- intros. rewrite seq_equiv. rewrite nth_mkseq.
-            ** apply big_ge_0_ex_abstract. intros.
-               apply /RleP. apply Rabs_pos.
-            ** by rewrite size_map size_enum_ord in H1.
-  - by rewrite size_map size_enum_ord in H.
+    { apply eq_big; auto. intros. apply Rabs_mult. }
+    rewrite {}H1. nra. } 
+  assert (\sum_(j < n.+1) \sum_(k < n.+1) (Rabs (A (inord i) k) * Rabs (B k j))%Re = 
+          \sum_(k < n.+1) \sum_(j < n.+1) (Rabs (A (inord i) k) * Rabs (B k j))%Re).
+  { apply exchange_big. } rewrite {}H0.
+  rewrite mulrC. rewrite -RmultE. 
+  remember (\big[maxr/0]_(i0 <- [seq \sum_(j < n.+1)  Rabs (B i0 j)  | i0 <- enum 'I_n.+1])  i0) as Bnorm.
+  rewrite -HeqBnorm. rewrite bigmax_mulr_0head.
+  2:{ rewrite size_map size_enum_ord //=. }
+  2:{ intros. move /mapP in H0. destruct H0 as [ix H1 H2]. rewrite H2.
+      apply /RleP. apply /RleP. apply sum_of_pos. intros. apply /RleP. apply Rabs_pos. }
+  2:{ rewrite HeqBnorm. apply matrix_inf_norm_nonneg. }
+  
+  assert ([seq (Bnorm * x)%Ri  | x <- [seq \sum_(j < n.+1)  Rabs (A i0 j)  | i0 <- enum 'I_n.+1]] = 
+          [seq Bnorm * \sum_(j < n.+1) Rabs (A i0 j)  | i0 <- enum 'I_n.+1]).
+  { rewrite -map_comp //=. } rewrite {}H0.
+  assert (\sum_(k < n.+1)  \sum_(j < n.+1)  (Rabs (A (inord i) k) * Rabs (B k j)) = 
+          \sum_(k < n.+1) (Rabs (A (inord i) k) * (\sum_(j < n.+1) Rabs (B k j)))).
+  { apply eq_big; auto. intros. rewrite sum_mult_distrl. auto. } rewrite {}H0.
+  assert (forall k, \sum_(j < n.+1)  Rabs (B k j) <= Bnorm).
+  { intros. rewrite HeqBnorm. apply /RleP. apply bigmax_ler_0head.
+    apply (@map_f _ _ (fun k => \sum_(j < n.+1) Rabs (B k j)) ).
+    apply mem_enum. intros. move /mapP in H0. destruct H0. rewrite H1.
+    apply sum_of_pos. intros. apply /RleP. apply Rabs_pos. } 
+  assert (\sum_(k < n.+1)  Rabs (A (inord i) k) * (\sum_(j < n.+1)  Rabs (B k j)) <= 
+          \sum_(k < n.+1) Rabs (A (inord i) k) * Bnorm).  
+  { apply sum_all_terms_le. intros. rewrite -!RmultE.
+    apply Rmult_le_compat_l. apply Rabs_pos. apply /RleP. apply H0. }
+  eapply Rle_trans. { apply /RleP. apply H1. } clear H0 H1.
+  assert (\sum_(k < n.+1)  Rabs (A (inord i) k) * Bnorm  = 
+    Bnorm * \sum_(k < n.+1)  Rabs (A (inord i) k)).
+  { rewrite sum_mult_distrr. rewrite -!RmultE Rmult_comm. auto. } rewrite {}H0.
+  apply bigmax_ler_0head.
+  { apply (@map_f _ _ (fun i0 => Bnorm * (\sum_(k < n.+1) Rabs (A i0 k))) (enum 'I_n.+1)).
+    apply mem_enum. }
+  intros. move /mapP in H0. destruct H0. rewrite H1. apply mulr_ge0.
+  + rewrite HeqBnorm. pose proof @matrix_inf_norm_nonneg. apply H2.
+  + apply sum_of_pos. intros. apply /RleP. apply Rabs_pos.
 Qed.
 
 
@@ -332,43 +309,30 @@ Lemma matrix_norm_add {n:nat}:
   forall (A B : 'M[R]_n.+1),
   matrix_inf_norm (A + B) <= matrix_inf_norm A + matrix_inf_norm B.
 Proof.
-intros. rewrite /matrix_inf_norm.
-apply /RleP. apply lemmas.bigmax_le.
-+ by rewrite size_map size_enum_ord //=.
-+ intros.
-  rewrite seq_equiv. rewrite nth_mkseq.
-  - rewrite /row_sum.
-    apply Rle_trans with 
-    (\sum_(j < n.+1) Rabs (A (inord i) j) + 
-     \sum_(j < n.+1) Rabs (B (inord i) j))%Re.
-    * assert (\sum_(j < n.+1) Rabs ((A + B)%Ri (inord i) j) = 
-              \sum_(j < n.+1) Rabs (A (inord i) j + B (inord i) j)).
-      { apply eq_big. by []. intros. rewrite !mxE. by rewrite -RplusE. }
-      rewrite H0. apply sum_abs_le .
-    * apply Rplus_le_compat.
-      ++ assert (\sum_(j < n.+1) Rabs (A (inord i) j) = 
-                  nth 0 [seq \sum_(j < n.+1) Rabs (A i0 j)
-                            | i0 <- enum 'I_n.+1] i).
-         { rewrite seq_equiv. rewrite nth_mkseq.
-           + by [].
-           + by rewrite size_map size_enum_ord in H.
-         } rewrite H0. apply /RleP.
-         apply (@bigmaxr_ler _ 0 [seq \sum_(j < n.+1) Rabs (A i0 j)
-                                      | i0 <- enum 'I_n.+1] i).
-         rewrite size_map size_enum_ord in H.
-         by rewrite size_map size_enum_ord.
-      ++ assert (\sum_(j < n.+1) Rabs (B (inord i) j) = 
-                  nth 0 [seq \sum_(j < n.+1) Rabs (B i0 j)
-                            | i0 <- enum 'I_n.+1] i).
-         { rewrite seq_equiv. rewrite nth_mkseq.
-           + by [].
-           + by rewrite size_map size_enum_ord in H.
-         } rewrite H0. apply /RleP.
-         apply (@bigmaxr_ler _ 0 [seq \sum_(j < n.+1) Rabs (B i0 j)
-                                      | i0 <- enum 'I_n.+1] i).
-         rewrite size_map size_enum_ord in H.
-         by rewrite size_map size_enum_ord.
-  - by rewrite size_map size_enum_ord in H.
+  intros. rewrite /matrix_inf_norm.
+  apply /RleP. apply bigmax_le_0head.
+  { rewrite size_map size_enum_ord //=. }
+  2:{ intros. move /mapP in H. destruct H as [ix H1 H2]. rewrite H2.
+      rewrite /row_sum. apply big_ge_0_ex_abstract. intros. apply /RleP. apply Rabs_pos. }
+  intros. rewrite (@nth_map _ 0).
+  2:{ rewrite size_map size_enum_ord in H. rewrite size_enum_ord. auto. }
+  rewrite enum_inord.
+  2:{ rewrite size_map size_enum_ord in H. auto. }
+  rewrite /row_sum.
+  apply Rle_trans with (\sum_(j < n.+1) Rabs (A (inord i) j) + \sum_(j < n.+1) Rabs (B (inord i) j))%Re.
+  { assert (\sum_(j < n.+1) Rabs ((A + B)%Ri (inord i) j) = 
+            \sum_(j < n.+1) Rabs (A (inord i) j + B (inord i) j)).
+    { apply eq_big; auto. intros. rewrite !mxE. rewrite -RplusE //=. }
+    rewrite {}H0. apply sum_abs_le. }
+  apply Rplus_le_compat.
+  + apply bigmax_ler_0head.
+    - apply (@map_f _ _ (fun i0 => \sum_(j < n.+1) Rabs (A i0 j))). apply mem_enum.
+    - intros. move /mapP in H0. destruct H0. rewrite H1. apply sum_of_pos. intros.
+      apply /RleP. apply Rabs_pos.
+  + apply bigmax_ler_0head.
+    - apply (@map_f _ _ (fun i0 => \sum_(j < n.+1) Rabs (B i0 j))). apply mem_enum.
+    - intros. move /mapP in H0. destruct H0. rewrite H1. apply sum_of_pos. intros.
+      apply /RleP. apply Rabs_pos.
 Qed.
 
 
@@ -397,35 +361,25 @@ Qed.
 Lemma matrix_inf_norm_1 {n:nat}:
   @matrix_inf_norm n.+1 1 = 1%Re.
 Proof.
-rewrite /matrix_inf_norm. rewrite seq_equiv.
-assert (mkseq (fun i : nat => row_sum 1 (@inord n i)) n.+1 = 
+  rewrite /matrix_inf_norm. rewrite seq_equiv.
+  assert (mkseq (fun i : nat => row_sum 1 (@inord n i)) n.+1 = 
           mkseq (fun i : nat => 1%Re) n.+1).
-{ apply eq_map. unfold eqfun. intros.
-  rewrite /row_sum. 
-  rewrite (bigD1 (inord x)) //=.
-  assert (\sum_(i < n.+1 | i != inord x) Rabs ((1%:M : 'M[R]_n.+1) (inord x) i) = 0%Re).
-  { rewrite big_0_ex_abstract.
-    + by [].
-    + intros. rewrite !mxE.
-      assert (inord x == i = false).
-      { rewrite eq_sym. apply /eqP. by apply /eqP. } rewrite H0 //=.
-      by rewrite Rabs_R0. 
-      } rewrite H !mxE //=.
-  rewrite addr0. 
-  assert (@inord n x == @inord n x = true).
-  { by apply /eqP. } rewrite H0 //=. by rewrite Rabs_R1.
-} rewrite H.
-apply bigmaxrP.
-split.
-+ assert (1%Re = nth 0 (mkseq (fun=> 1) n.+1) 0).
-  { by rewrite nth_mkseq. } rewrite H0. rewrite inE //=. 
-  apply /orP. by left.
-+ intros. rewrite nth_mkseq.
-  - apply /RleP. apply Rle_refl.
-  - assert (mkseq (fun i : nat => 1%Re) n.+1 = 
-             [seq 1%Re | i <- enum 'I_n.+1]).
-    { by rewrite seq_equiv. } rewrite H1 in H0.
-    rewrite size_map size_enum_ord //= in H0.
+  { apply eq_map. unfold eqfun. intros.
+    rewrite /row_sum. 
+    rewrite (bigD1 (inord x)) //=.
+    assert (\sum_(i < n.+1 | i != inord x) Rabs ((1%:M : 'M[R]_n.+1) (inord x) i) = 0%Re).
+    { rewrite big_0_ex_abstract.
+      + by [].
+      + intros. rewrite !mxE.
+        assert (inord x == i = false).
+        { rewrite eq_sym. apply /eqP. by apply /eqP. } rewrite H0 //=.
+        by rewrite Rabs_R0. 
+        } rewrite H !mxE //=.
+    rewrite addr0. 
+    assert (@inord n x == @inord n x = true).
+    { by apply /eqP. } rewrite H0 //=. by rewrite Rabs_R1.
+  } rewrite {}H.  
+  rewrite /mkseq. apply bigmax_const_seq. lra.
 Qed.
 
 

--- a/jacob_list_fun_model.v
+++ b/jacob_list_fun_model.v
@@ -88,7 +88,7 @@ Lemma length_diag_of_matrix: forall {t} (m: matrix t),
 Proof.
  intros.
  unfold diag_of_matrix.
- rewrite map_length. rewrite seq_length. auto.
+ rewrite length_map. rewrite length_seq. auto.
 Qed.
 
 Lemma rows_matrix_of_diag: forall {t} (v: diagmatrix t),
@@ -114,7 +114,7 @@ Proof.
 intros.
 unfold diag_of_matrix, matrix_of_diag.
 apply (all_nth_eq (Zconst t 0));
-rewrite map_length, seq_length, matrix_by_index_rows. auto.
+rewrite length_map, length_seq, matrix_by_index_rows. auto.
 intros.
 set (f := fun _ => _).
 transitivity (nth i (map f (seq 0 (length d))) (f (length d))).
@@ -124,7 +124,7 @@ unfold matrix_index.
 rewrite nth_overflow; auto.
 rewrite nth_overflow; auto.
 simpl; lia.
-rewrite map_length. rewrite seq_length. lia.
+rewrite length_map. rewrite length_seq. lia.
 rewrite map_nth.
 rewrite seq_nth by auto.
 simpl.
@@ -173,8 +173,8 @@ clear H.
 revert m2 H1; induction H0; destruct m2; simpl; intros; constructor.
 inv H1.
 unfold uncurry, map2.
-rewrite map_length.
-rewrite combine_length.
+rewrite length_map.
+rewrite length_combine.
 rewrite H4. apply  Nat.min_id.
 apply IHForall.
 inv H1; auto.
@@ -224,8 +224,8 @@ Proof.
 intros.
 unfold matrix_rows_nat in *.
 unfold map2.
-rewrite map_length.
-rewrite combine_length.
+rewrite length_map.
+rewrite length_combine.
 lia.
 Qed.
 
@@ -244,8 +244,8 @@ unfold map2 at 1.
 unfold combine; fold (combine m1 m2).
 simpl.
 constructor; auto.
-unfold map2. rewrite map_length.
-rewrite combine_length; lia.
+unfold map2. rewrite length_map.
+rewrite length_combine; lia.
 apply IHm1; auto.
 Qed.
 
@@ -257,7 +257,7 @@ Proof.
 induction 1.
 constructor.
 constructor.
-rewrite map_length. auto.
+rewrite length_map. auto.
 apply IHForall.
 Qed.
 

--- a/jacobi_iteration_bound.v
+++ b/jacobi_iteration_bound.v
@@ -720,9 +720,13 @@ apply Rlt_le_trans with
 [seq Rabs (v i 0) | i <- enum 'I_n.+1]`_0.
 + rewrite seq_equiv. rewrite nth_mkseq; last by [].
   specialize (H (@inord n 0)). by apply Rabs_pos_lt.
-+ apply /RleP.
-  apply (@bigmaxr_ler _ 0%Re [seq Rabs (v i 0) | i <- enum 'I_n.+1] 0).
-  by rewrite size_map size_enum_ord.
++ apply bigmax_ler_0head.
+  { apply /mapP. exists ord0. apply mem_enum.
+    rewrite (@nth_map _ ord0). f_equal. f_equal.
+    rewrite (@nth_ord_enum n.+1 ord0 0). auto.
+    by rewrite size_enum_ord. }
+  intros. move /mapP in H0. destruct H0 as [x0 ? ?]. rewrite H1.
+  apply /RleP. apply Rabs_pos.
 Qed.
 
 
@@ -1217,12 +1221,12 @@ repeat split.
     rewrite nth_map_seq.
     * unfold matrix_index. rewrite inordK in Hfdiv.
       ++ apply Hfdiv.
-      ++ rewrite Heqn prednK. rewrite !map_length seq_length /matrix_rows_nat in H.
+      ++ rewrite Heqn prednK. rewrite !length_map length_seq /matrix_rows_nat in H.
          by apply /ssrnat.ltP. by apply /ssrnat.ltP.
     * unfold matrix_rows_nat. 
-      by rewrite !map_length seq_length /matrix_rows_nat in H.
-  - rewrite !map_length seq_length.
-    by rewrite !map_length seq_length in H.
+      by rewrite !length_map length_seq /matrix_rows_nat in H.
+  - rewrite !length_map length_seq.
+    by rewrite !length_map length_seq in H.
 + apply Forall_forall. intros.
   pose proof (@In_nth _ b x (Zconst t 0)).
   specialize (H0 H). destruct H0 as [i [Hjb H0]].
@@ -1257,17 +1261,17 @@ assert (fma_dotprod t v v = dotprod v v).
 { by unfold fma_dotprod, dotprod. }
 rewrite H2 in H1. specialize (H0 H1).
 rewrite -rev_combine in H0; last by [].
-rewrite rev_length combine_length Nat.min_id in H0.
+rewrite length_rev length_combine Nat.min_id in H0.
 apply H0.
 apply Hg1.
 intros.
 repeat split;
 try (specialize (H x.1); apply in_rev in H3;
       destruct x; apply in_combine_l in H3; simpl in *;
-      apply in_rev in H3; try rewrite rev_length in H;by apply H);
+      apply in_rev in H3; try rewrite length_rev in H;by apply H);
 try (specialize (H x.2); apply in_rev in H3;
       destruct x; apply in_combine_r in H3; simpl in *;
-      apply in_rev in H3; try rewrite rev_length in H;by apply H).
+      apply in_rev in H3; try rewrite length_rev in H;by apply H).
 Qed.
 
 
@@ -1860,7 +1864,7 @@ Lemma residual_finite {t: FPStdLib.type} {n:nat}
 Proof.
 intros ? ? ? ? ? ? ? Hcond Hf0.
 unfold norm2. apply dotprod_finite.
-rewrite rev_length length_veclist.
+rewrite length_rev length_veclist.
 apply g1_constraint_Sn. 
 apply Hcond.
 intros.
@@ -1873,16 +1877,16 @@ repeat split.
                                   X_m_jacobi k x0 b A)))) xy (Zconst t 0) H).
   destruct H0 as [m [Hlenk Hmth]].
   rewrite -Hmth.
-  rewrite rev_nth; last by rewrite rev_length in Hlenk.
+  rewrite rev_nth; last by rewrite length_rev in Hlenk.
   rewrite length_veclist.
   assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat).
   { lia. } rewrite H0.
   rewrite nth_vec_to_list_float; 
-  last by (rewrite rev_length length_veclist in Hlenk; apply /ssrnat.ltP).
+  last by (rewrite length_rev length_veclist in Hlenk; apply /ssrnat.ltP).
   rewrite !mxE.
   repeat (rewrite nth_vec_to_list_float; last by 
   (rewrite inordK;
-   rewrite rev_length length_veclist in Hlenk;
+   rewrite length_rev length_veclist in Hlenk;
    apply /ssrnat.ltP)).
   rewrite mxE inord_val.
   apply BMULT_no_overflow_is_finite.
@@ -1924,7 +1928,7 @@ repeat split.
       apply Rcomplements.Rlt_div_r.
       apply Rplus_lt_le_0_compat; try nra; try apply default_rel_ge_0.
       apply no_overflow_xkp1_minus_xk; try by [].
-      by rewrite rev_length length_veclist in Hlenk.
+      by rewrite length_rev length_veclist in Hlenk.
   - unfold Bmult_no_overflow. unfold rounded.
     pose proof (@generic_round_property t 
                 (FT2R (A (inord m) (inord m)) *
@@ -1947,7 +1951,7 @@ repeat split.
     assert (finite (BPLUS (X_m_jacobi k.+1 x0 b A (inord m) ord0)
                   (BOPP  (X_m_jacobi k x0 b A (inord m) ord0)))).
     { apply finite_xkp1_minus_xk; try by [].
-      by rewrite rev_length length_veclist in Hlenk.
+      by rewrite length_rev length_veclist in Hlenk.
     }
     rewrite Bminus_bplus_opp_equiv.
     * pose proof (@BPLUS_accurate' _ t).
@@ -1969,7 +1973,7 @@ repeat split.
       apply Rplus_lt_le_0_compat; try nra; try apply default_rel_ge_0.
       pose proof (@res_xkp1_minus_xk  t n A x0 b k m).
       assert ((m < n.+1)%nat). 
-      { rewrite rev_length length_veclist in Hlenk. by apply /ssrnat.ltP. }
+      { rewrite length_rev length_veclist in Hlenk. by apply /ssrnat.ltP. }
       specialize (H4 H5 Hcond Hf0).
       eapply Rlt_trans. 
       apply H4. 
@@ -1979,7 +1983,7 @@ repeat split.
       apply Rplus_lt_compat_r.
       apply sqrt_fun_bnd_lt_fmax. apply Hcond.
     * apply H2.
-+ rewrite !rev_length  length_veclist.
++ rewrite !length_rev  length_veclist.
   rewrite rev_involutive in H.
   unfold residual_math in H.
   apply in_rev in H. 
@@ -1990,16 +1994,16 @@ repeat split.
                                   X_m_jacobi k x0 b A)))) xy (Zconst t 0) H).
   destruct H0 as [m [Hlenk Hmth]].
   rewrite -Hmth.
-  rewrite rev_nth; last by rewrite rev_length in Hlenk.
+  rewrite rev_nth; last by rewrite length_rev in Hlenk.
   rewrite length_veclist.
   assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat).
   { lia. } rewrite H0.
   rewrite nth_vec_to_list_float; 
-  last by (rewrite rev_length length_veclist in Hlenk; apply /ssrnat.ltP).
+  last by (rewrite length_rev length_veclist in Hlenk; apply /ssrnat.ltP).
   rewrite !mxE.
   repeat (rewrite nth_vec_to_list_float; last by 
   (rewrite inordK;
-   rewrite rev_length length_veclist in Hlenk;
+   rewrite length_rev length_veclist in Hlenk;
    apply /ssrnat.ltP)).
   rewrite mxE inord_val.
   pose proof (@BMULT_accurate' _ t).
@@ -2012,7 +2016,7 @@ repeat split.
                   X_m_jacobi k x0 b A) 
                    (inord m) ord0))).
   { apply finite_Bmult_res; try by [].
-    by rewrite rev_length length_veclist in Hlenk.
+    by rewrite length_rev length_veclist in Hlenk.
   }
   specialize (H1 H2).
   destruct H1 as [d5 [e5 [Hde5 [Hd5 [He5 H1]]]]].
@@ -2036,7 +2040,7 @@ repeat split.
                      (X_m_jacobi k x0 b A
                         (inord m) ord0))) ).
   { apply finite_xkp1_minus_xk; try by [].
-     by rewrite rev_length length_veclist in Hlenk.
+     by rewrite length_rev length_veclist in Hlenk.
   }
   rewrite Bminus_bplus_opp_equiv.
   - pose proof (@BPLUS_accurate' _ t).
@@ -2057,7 +2061,7 @@ repeat split.
     unfold n0.
     rewrite [in X in (_ * (Rabs (_ + X)) < _)%Re]/FT2R B2R_Bopp.
     fold (@FT2R t). apply res_xkp1_minus_xk.
-    rewrite rev_length length_veclist in Hlenk. by apply /ssrnat.ltP.
+    rewrite length_rev length_veclist in Hlenk. by apply /ssrnat.ltP.
     apply Hcond. apply Hf0.
   - apply H3.
 Qed.
@@ -2128,10 +2132,10 @@ unfold resid, jacobi_residual.
                          by apply /ssrnat.ltP.
                        } rewrite H3. apply ltn_ord.
                     ++ unfold matrix_vector_mult. 
-                       rewrite !map_length seq_length.
+                       rewrite !length_map length_seq.
                        by unfold matrix_rows_nat.
-                  * rewrite combine_length. 
-                    rewrite !map_length !seq_length /matrix_rows_nat.
+                  * rewrite length_combine. 
+                    rewrite !length_map !length_seq /matrix_rows_nat.
                     rewrite H Nat.min_id.
                     assert (length A  = n.+1).
                     { unfold n. rewrite prednK. by []. 
@@ -2141,10 +2145,10 @@ unfold resid, jacobi_residual.
                     { unfold n. rewrite prednK. by []. 
                       by apply /ssrnat.ltP.
                     } rewrite H3. apply /ssrnat.ltP. apply ltn_ord.
-                - rewrite !map_length !seq_length /matrix_rows_nat.
-                  rewrite combine_length !map_length !seq_length /matrix_rows_nat.
+                - rewrite !length_map !length_seq /matrix_rows_nat.
+                  rewrite length_combine !length_map !length_seq /matrix_rows_nat.
                   by rewrite H Nat.min_id.
-            + repeat rewrite combine_length !map_length !seq_length /matrix_rows_nat.
+            + repeat rewrite length_combine !length_map !length_seq /matrix_rows_nat.
               rewrite H !Nat.min_id.
               assert (length A  = n.+1).
                     { unfold n. rewrite prednK. by []. 
@@ -2154,16 +2158,16 @@ unfold resid, jacobi_residual.
           unfold jacobi_n, jacob_list_fun_model.jacobi_iter.
           rewrite iter_length; last by []; last by [].  
           unfold diagmatrix_vector_mult, map2, uncurry.
-          repeat rewrite !map_length !combine_length.
+          repeat rewrite !length_map !length_combine.
           unfold matrix_vector_mult.
-          rewrite !map_length. rewrite !seq_length.
+          rewrite !length_map. rewrite !length_seq.
           unfold matrix_rows_nat. by rewrite H !Nat.min_id.
-       -- rewrite combine_length. unfold jacobi_n.
+       -- rewrite length_combine. unfold jacobi_n.
           unfold jacob_list_fun_model.jacobi_iter.
           rewrite iter_length; last by []; last by [].
-          repeat rewrite !map_length !combine_length.
-          rewrite seq_length !map_length.
-          rewrite seq_length /matrix_rows_nat H !Nat.min_id.
+          repeat rewrite !length_map !length_combine.
+          rewrite length_seq !length_map.
+          rewrite length_seq /matrix_rows_nat H !Nat.min_id.
           assert (length A  = n.+1).
           { unfold n. rewrite prednK. by []. 
             by apply /ssrnat.ltP.
@@ -2173,22 +2177,22 @@ unfold resid, jacobi_residual.
          { rewrite /n prednK. by []. by apply /ssrnat.ltP. }
          rewrite H2. apply ltn_ord.
    * unfold vector_sub, map2, uncurry, jacobi_n.
-     rewrite !map_length combine_length. 
+     rewrite !length_map length_combine. 
      unfold jacob_list_fun_model.jacobi_iter.
-     repeat rewrite !map_length !combine_length iter_length;
+     repeat rewrite !length_map !length_combine iter_length;
      last by []; last by [].
-     repeat rewrite /matrix_vector_mult !map_length !combine_length .
-     rewrite !map_length /matrix_rows_nat.
-     by rewrite !seq_length H !Nat.min_id.
- - rewrite combine_length. 
-   rewrite !map_length !combine_length. 
+     repeat rewrite /matrix_vector_mult !length_map !length_combine .
+     rewrite !length_map /matrix_rows_nat.
+     by rewrite !length_seq H !Nat.min_id.
+ - rewrite length_combine. 
+   rewrite !length_map !length_combine. 
     unfold jacob_list_fun_model.jacobi_iter.
-     repeat rewrite !map_length !combine_length iter_length;
+     repeat rewrite !length_map !length_combine iter_length;
      last by []; last by [].
-    rewrite !map_length /matrix_rows_nat !combine_length.
-    repeat rewrite /matrix_vector_mult !map_length !combine_length .
-     rewrite !map_length /matrix_rows_nat.
-    rewrite !seq_length H !Nat.min_id.
+    rewrite !length_map /matrix_rows_nat !length_combine.
+    repeat rewrite /matrix_vector_mult !length_map !length_combine .
+     rewrite !length_map /matrix_rows_nat.
+    rewrite !length_seq H !Nat.min_id.
     assert (length A  = n.+1).
     { unfold n. rewrite prednK. by []. 
       by apply /ssrnat.ltP.
@@ -2306,7 +2310,7 @@ assert (forall xy : ftype t * ftype t,
                      X_m_jacobi k x0 b A))))).
   { rewrite rev_nth. apply nth_In. rewrite Heqv_l in Hm.
     rewrite length_veclist . lia. rewrite Heqv_l in Hm.
-    rewrite rev_length combine_length !length_veclist Nat.min_id in Hm.
+    rewrite length_rev length_combine !length_veclist Nat.min_id in Hm.
     by rewrite !length_veclist.
   } specialize (H3 H4).
   rewrite rev_nth in H3.
@@ -2317,20 +2321,20 @@ assert (forall xy : ftype t * ftype t,
   + rewrite !mxE in H3. 
     rewrite nth_vec_to_list_float in H3.
     - rewrite nth_vec_to_list_float in H3; last 
-      by rewrite inordK; rewrite  Heqv_l  rev_length combine_length !length_veclist Nat.min_id in Hm;
+      by rewrite inordK; rewrite  Heqv_l  length_rev length_combine !length_veclist Nat.min_id in Hm;
       apply /ssrnat.ltP.
       apply BMULT_finite_e in H3.
       destruct H3 as [Hf1 Hf2].
       rewrite mxE in Hf2.
       apply Bminus_bplus_opp_implies in Hf2.
       rewrite Heqv_l in Hnth. rewrite rev_nth in Hnth.
-      rewrite combine_length !length_veclist Nat.min_id in Hnth.
+      rewrite length_combine !length_veclist Nat.min_id in Hnth.
       rewrite combine_nth in Hnth.
       assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat).
       { lia. } rewrite H3 in Hnth. 
       rewrite nth_vec_to_list_float in Hnth.
       * rewrite nth_vec_to_list_float in Hnth;
-        last by  rewrite  Heqv_l  rev_length combine_length !length_veclist Nat.min_id in Hm;
+        last by  rewrite  Heqv_l  length_rev length_combine !length_veclist Nat.min_id in Hm;
            apply /ssrnat.ltP. 
         rewrite inord_val in Hf2.
         assert (finite (X_m_jacobi k.+1 x0 b A
@@ -2354,16 +2358,16 @@ assert (forall xy : ftype t * ftype t,
           destruct Hnth as [Hnth1 Hnth2].
           by rewrite Hnth2.
         } rewrite H7 H8. repeat split; try apply H6; try apply Hf2.
-      * by  rewrite  Heqv_l  rev_length combine_length !length_veclist Nat.min_id in Hm;
+      * by  rewrite  Heqv_l  length_rev length_combine !length_veclist Nat.min_id in Hm;
         apply /ssrnat.ltP.
       * by rewrite !length_veclist.
-      * rewrite Heqv_l in Hm. by rewrite rev_length in Hm.
-    - by rewrite inordK; rewrite  Heqv_l  rev_length combine_length !length_veclist Nat.min_id in Hm;
+      * rewrite Heqv_l in Hm. by rewrite length_rev in Hm.
+    - by rewrite inordK; rewrite  Heqv_l  length_rev length_combine !length_veclist Nat.min_id in Hm;
       apply /ssrnat.ltP.
-  + rewrite  Heqv_l rev_length combine_length !length_veclist Nat.min_id in Hm.
+  + rewrite  Heqv_l length_rev length_combine !length_veclist Nat.min_id in Hm.
     by apply /ssrnat.ltP.
   + rewrite length_veclist.
-    by rewrite  Heqv_l rev_length combine_length !length_veclist Nat.min_id in Hm.
+    by rewrite  Heqv_l length_rev length_combine !length_veclist Nat.min_id in Hm.
 } specialize (H H0).
 apply reverse_triang_ineq in H.
 apply Rle_trans with
@@ -2612,7 +2616,7 @@ eapply Rle_trans.
                    (residual_math A x0 b k)))).
     { rewrite rev_nth. apply nth_In. rewrite Heqr_l in Hm.
       rewrite length_veclist . lia. rewrite Heqr_l in Hm.
-      rewrite rev_length combine_length !length_veclist Nat.min_id in Hm.
+      rewrite length_rev length_combine !length_veclist Nat.min_id in Hm.
       by rewrite !length_veclist.
     } specialize (H2 H3). 
     rewrite Heqr_l in Hnth.
@@ -2714,7 +2718,7 @@ eapply Rle_trans.
                                  X_m_jacobi k x0 b A))))).
               { rewrite rev_nth. apply nth_In. rewrite Heqr_l in Hm.
                 rewrite length_veclist . lia. rewrite Heqr_l in Hm.
-                rewrite rev_length combine_length !length_veclist Nat.min_id in Hm.
+                rewrite length_rev length_combine !length_veclist Nat.min_id in Hm.
                 by rewrite !length_veclist.
               } specialize (H3 H4).
               rewrite rev_nth in H3.
@@ -2725,11 +2729,11 @@ eapply Rle_trans.
               + rewrite !mxE in H3.
                 rewrite nth_vec_to_list_float in H3; last 
                 by rewrite inordK;
-                 rewrite   Heqr_l  rev_length combine_length !length_veclist Nat.min_id in Hm;
+                 rewrite   Heqr_l  length_rev length_combine !length_veclist Nat.min_id in Hm;
                   apply /ssrnat.ltP.
                 rewrite nth_vec_to_list_float in H3; last 
                 by rewrite inordK;
-                 rewrite   Heqr_l  rev_length combine_length !length_veclist Nat.min_id in Hm;
+                 rewrite   Heqr_l  length_rev length_combine !length_veclist Nat.min_id in Hm;
                   apply /ssrnat.ltP.
                 rewrite inord_val in H3. 
                 assert (finite (A1_J A (inord m) ord0) /\
@@ -2738,11 +2742,11 @@ eapply Rle_trans.
                 { apply BMULT_finite_e  in H3.
                   split; try apply H3.
                 }  rewrite Heqr_l in Hnth. rewrite rev_nth in Hnth.
-                rewrite combine_length !length_veclist Nat.min_id in Hnth.
+                rewrite length_combine !length_veclist Nat.min_id in Hnth.
                 assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat).
                 { lia. } rewrite H7 in Hnth. rewrite combine_nth in Hnth.
                repeat (rewrite nth_vec_to_list_float in Hnth; last 
-                by rewrite   Heqr_l  rev_length combine_length !length_veclist Nat.min_id in Hm;
+                by rewrite   Heqr_l  length_rev length_combine !length_veclist Nat.min_id in Hm;
                   apply /ssrnat.ltP).
                - assert (xy.1 =(A1_J A (inord m) ord0)).
                   { destruct xy. simpl in *. 
@@ -2758,10 +2762,10 @@ eapply Rle_trans.
                     by rewrite Hnth2.
                   } rewrite H8 H9. split. apply H6. split. apply H6. apply H3.
                - by rewrite !length_veclist.
-               - by rewrite Heqr_l rev_length in Hm. 
-             + by rewrite   Heqr_l  rev_length combine_length !length_veclist Nat.min_id in Hm;
+               - by rewrite Heqr_l length_rev in Hm. 
+             + by rewrite   Heqr_l  length_rev length_combine !length_veclist Nat.min_id in Hm;
                   apply /ssrnat.ltP.
-             + rewrite Heqr_l rev_length combine_length !length_veclist Nat.min_id in Hm.
+             + rewrite Heqr_l length_rev length_combine !length_veclist Nat.min_id in Hm.
                by rewrite length_veclist.
            (** Implied by finiteness of the residual **) } specialize (H H0).
             assert ((vec_inf_norm
@@ -3174,9 +3178,9 @@ split.
     pose proof (@v_equiv t).
     specialize (H7 (resid (jacobi_n A b x0 i)) n).
     assert (length (resid (jacobi_n A b x0 i)) = n.+1).
-    { repeat rewrite /matrix_vector_mult !map_length combine_length.
-      rewrite !map_length. unfold jacobi_n. rewrite iter_length.
-      rewrite !seq_length /matrix_rows_nat H4 !Nat.min_id.
+    { repeat rewrite /matrix_vector_mult !length_map length_combine.
+      rewrite !length_map. unfold jacobi_n. rewrite iter_length.
+      rewrite !length_seq /matrix_rows_nat H4 !Nat.min_id.
       rewrite /n prednK. by []. by apply /ssrnat.ltP.
       by []. by []. 
     }
@@ -3203,9 +3207,9 @@ split.
     pose proof (@v_equiv t).
     specialize (H6 (resid (jacobi_n A b x0 j)) n).
     assert (length (resid (jacobi_n A b x0 j)) = n.+1).
-    { repeat rewrite /matrix_vector_mult !map_length combine_length.
-      rewrite !map_length. unfold jacobi_n. rewrite iter_length.
-      rewrite !seq_length H3 !Nat.min_id.
+    { repeat rewrite /matrix_vector_mult !length_map length_combine.
+      rewrite !length_map. unfold jacobi_n. rewrite iter_length.
+      rewrite !length_seq H3 !Nat.min_id.
       rewrite -/n prednK. by []. by apply /ssrnat.ltP.
       by []. by [].
     }
@@ -3372,9 +3376,9 @@ pose proof (@In_nth _ (rev (combine
           (vec_to_list_float n.+1
              (\col_j x0' j ord0)))) x (Zconst t 0, Zconst t 0) H6).
 destruct H7 as [p [Hlenp Hnth]].
-rewrite rev_length combine_length !length_veclist Nat.min_id in Hlenp.
+rewrite length_rev length_combine !length_veclist Nat.min_id in Hlenp.
 rewrite rev_nth in Hnth.
-rewrite combine_length !length_veclist Nat.min_id in Hnth.
+rewrite length_combine !length_veclist Nat.min_id in Hnth.
 assert ((n.+1 - p.+1)%coq_nat = (n.+1.-1 - p)%coq_nat) by lia.
 rewrite H7 in Hnth. rewrite combine_nth in Hnth.
 rewrite !nth_vec_to_list_float in Hnth.
@@ -3392,7 +3396,7 @@ by apply g1_constraint.
 by apply /ssrnat.ltP.
 by apply /ssrnat.ltP.
 by rewrite !length_veclist.
-by rewrite combine_length !length_veclist Nat.min_id.
+by rewrite length_combine !length_veclist Nat.min_id.
 Qed.
 
 
@@ -3435,7 +3439,7 @@ specialize (H6 (dotprod_r
 pose proof (@fma_dot_prod_rel_holds _ n t n.+1 k (A2_J A')
                     (\col_j x0' j ord0)).
 specialize (H6 H7). clear H7.
-rewrite combine_length !length_veclist Nat.min_id in H6.
+rewrite length_combine !length_veclist Nat.min_id in H6.
 apply finite_is_finite.
 apply H6.
 + by apply g1_constraint_Sn. 
@@ -3553,12 +3557,12 @@ assert ((let l1 :=
     assert (forall l l': vector t, (l, l').2 = l').
     { intros. by simpl. } rewrite H4 in H2.
     apply H2. 
-    + rewrite combine_length !length_veclist Nat.min_id.
+    + rewrite length_combine !length_veclist Nat.min_id.
       intros. 
       rewrite nth_vec_to_list_float; last by apply /ssrnat.ltP.
       rewrite mxE. rewrite mxE. 
       unfold x0. rewrite nth_repeat /=. by left.
-   + rewrite combine_length !length_veclist Nat.min_id.
+   + rewrite length_combine !length_veclist Nat.min_id.
       intros. rewrite nth_vec_to_list_float; last by apply /ssrnat.ltP.
       rewrite mxE. by rewrite mxE.
   } rewrite inord_val in H2. by rewrite H2.
@@ -4038,9 +4042,9 @@ pose proof (@In_nth _ (rev (combine
                               n.+1)))) xy (Zconst t 0, Zconst t 0)).
 specialize (H2 H1).
 destruct H2 as [k [Hlen Hnth]].
-rewrite rev_length combine_length !length_veclist Nat.min_id in Hlen.
+rewrite length_rev length_combine !length_veclist Nat.min_id in Hlen.
 rewrite rev_nth in Hnth.
-rewrite combine_length !length_veclist Nat.min_id in Hnth.
+rewrite length_combine !length_veclist Nat.min_id in Hnth.
 assert ((n.+1 - k.+1)%coq_nat = (n.+1.-1 - k)%coq_nat) by lia.
 rewrite combine_nth in Hnth.
 destruct xy . simpl. 
@@ -4064,7 +4068,7 @@ apply Hlen.
 apply Hlen.
 by apply /ssrnat.ltP.
 by rewrite !length_veclist.
-by rewrite combine_length !length_veclist Nat.min_id.
+by rewrite length_combine !length_veclist Nat.min_id.
 Qed.
 
 
@@ -4090,9 +4094,9 @@ Proof.
 intros ? ? ? ? ? ? ? ? ? ? ? HfA2 Hfx0 Hinp HfA HfA1_inv Hfb.
 unfold norm2. 
 assert ( length (resid (jacobi_n A b x0 0)) = n.+1).
-{ repeat rewrite /matrix_vector_mult !map_length combine_length.
-    rewrite !map_length. unfold jacobi_n. rewrite iter_length.
-    rewrite !seq_length /matrix_rows_nat H0 !Nat.min_id.
+{ repeat rewrite /matrix_vector_mult !length_map length_combine.
+    rewrite !length_map. unfold jacobi_n. rewrite iter_length.
+    rewrite !length_seq /matrix_rows_nat H0 !Nat.min_id.
     rewrite -/n prednK. by []. by apply /ssrnat.ltP.
     by []. by rewrite /x0 repeat_length.
 }
@@ -4125,7 +4129,7 @@ apply dotprod_finite.
     rewrite -/n. rewrite H2 in Hlen.
     rewrite inordK; try by apply /ssrnat.ltP.
     apply Hlen.
-  - intros. unfold n0. rewrite rev_length. rewrite H2.
+  - intros. unfold n0. rewrite length_rev. rewrite H2.
     pose proof (@BMULT_accurate' _ t).
     rewrite inordK.
     specialize (H7 (nth (n.+1.-1 - k)
@@ -4239,9 +4243,9 @@ specialize (H3 (rev (resid (jacobi_n A b x0 0)))).
 rewrite rev_involutive in H3.
 specialize (H3 H1).
 assert (Hrlen: length (resid (jacobi_n A b x0 0)) = n.+1).
-{ repeat rewrite /matrix_vector_mult !map_length combine_length.
-    rewrite !map_length. unfold jacobi_n. rewrite iter_length.
-    rewrite !seq_length /matrix_rows_nat H0 !Nat.min_id.
+{ repeat rewrite /matrix_vector_mult !length_map length_combine.
+    rewrite !length_map. unfold jacobi_n. rewrite iter_length.
+    rewrite !length_seq /matrix_rows_nat H0 !Nat.min_id.
     rewrite /n prednK. by []. by apply /ssrnat.ltP.
     by []. by rewrite /x0 repeat_length.
 }
@@ -4256,7 +4260,7 @@ assert (finite (BMULT xy.1 xy.2)).
                             X_m_jacobi 0 x0' b' A')))) xy (Zconst t 0, Zconst t 0)).
   specialize (H4 H2).
   destruct H4 as [k [Hlen Hnth]].
-  rewrite rev_length combine_length !length_veclist Nat.min_id in Hlen.
+  rewrite length_rev length_combine !length_veclist Nat.min_id in Hlen.
   assert (BMULT xy.1 xy.2 = 
           nth k (resid (jacobi_n A b x0 0)) (Zconst t 0)).
   { assert (resid (jacobi_n A b x0 0) = 
@@ -4287,7 +4291,7 @@ assert (finite (BMULT xy.1 xy.2)).
     apply /ssrnat.ltP. apply Hlen.
     apply Hlen.
     apply Hlen.
-    by rewrite !rev_length !length_veclist.
+    by rewrite !length_rev !length_veclist.
     by rewrite !length_veclist.
     apply /ssrnat.ltP. apply Hlen.
     unfold x0. by rewrite repeat_length.
@@ -4340,13 +4344,13 @@ pose proof (@In_nth _ (rev
 specialize (H4 H2).
 destruct H4 as [k [Hlen Hnth]].
 assert (Hrlen: length (resid (jacobi_n A b x0 0)) = n.+1).
-{ repeat rewrite /matrix_vector_mult !map_length combine_length.
-    rewrite !map_length. unfold jacobi_n. rewrite iter_length.
-    rewrite !seq_length /matrix_rows_nat H0 !Nat.min_id.
+{ repeat rewrite /matrix_vector_mult !length_map length_combine.
+    rewrite !length_map. unfold jacobi_n. rewrite iter_length.
+    rewrite !length_seq /matrix_rows_nat H0 !Nat.min_id.
     rewrite /n prednK. by []. by apply /ssrnat.ltP.
     by []. by rewrite /x0 repeat_length.
 }
-rewrite rev_length combine_length !length_veclist Nat.min_id in Hlen.
+rewrite length_rev length_combine !length_veclist Nat.min_id in Hlen.
 specialize (H3 (BMULT
                   (nth (n.+1.-1 - @inord n k)
                      (vec_to_list_float n.+1 (A1_J A'))
@@ -4413,7 +4417,7 @@ rewrite nth_vec_to_list_float in H32.
 rewrite mxE in H32.
 apply Bminus_bplus_opp_implies in H32.
 destruct xy.
-rewrite rev_nth combine_length !length_veclist Nat.min_id in Hnth.
+rewrite rev_nth length_combine !length_veclist Nat.min_id in Hnth.
 assert ((n.+1 - k.+1)%coq_nat = (n.+1.-1 - k)%coq_nat) by lia.
 rewrite H3 in Hnth.
 rewrite combine_nth in Hnth.
@@ -4493,13 +4497,13 @@ pose proof (@In_nth _ (rev
 specialize (H4 H2).
 destruct H4 as [k [Hlen Hnth]].
 assert (Hrlen: length (resid (jacobi_n A b x0 0)) = n.+1).
-{ repeat rewrite /matrix_vector_mult !map_length combine_length.
-    rewrite !map_length. unfold jacobi_n. rewrite iter_length.
-    rewrite !seq_length /matrix_rows_nat H0 !Nat.min_id.
+{ repeat rewrite /matrix_vector_mult !length_map length_combine.
+    rewrite !length_map. unfold jacobi_n. rewrite iter_length.
+    rewrite !length_seq /matrix_rows_nat H0 !Nat.min_id.
     rewrite /n prednK. by []. by apply /ssrnat.ltP.
     by []. by rewrite /x0 repeat_length.
 }
-rewrite rev_length combine_length !length_veclist Nat.min_id in Hlen.
+rewrite length_rev length_combine !length_veclist Nat.min_id in Hlen.
 specialize (H3 (BMULT
                   (nth (n.+1.-1 - @inord n k)
                      (vec_to_list_float n.+1 (A1_J A'))
@@ -4570,7 +4574,7 @@ apply BPLUS_finite_e in H3.
 destruct H3 as [H3 _]. rewrite mxE in H3.
 rewrite inordK in H3.
 destruct xy .
-rewrite rev_nth combine_length !length_veclist Nat.min_id in Hnth.
+rewrite rev_nth length_combine !length_veclist Nat.min_id in Hnth.
 assert ((n.+1 - k.+1)%coq_nat = (n.+1.-1 - k)%coq_nat) by lia.
 rewrite H5 in Hnth.
 rewrite combine_nth in Hnth.
@@ -4627,13 +4631,13 @@ pose proof (@In_nth _ (rev
 specialize (H4 H2).
 destruct H4 as [k [Hlen Hnth]].
 assert (Hrlen: length (resid (jacobi_n A b x0 0)) = n.+1).
-{ repeat rewrite /matrix_vector_mult !map_length combine_length.
-    rewrite !map_length. unfold jacobi_n. rewrite iter_length.
-    rewrite !seq_length /matrix_rows_nat H0 !Nat.min_id.
+{ repeat rewrite /matrix_vector_mult !length_map length_combine.
+    rewrite !length_map. unfold jacobi_n. rewrite iter_length.
+    rewrite !length_seq /matrix_rows_nat H0 !Nat.min_id.
     rewrite /n prednK. by []. by apply /ssrnat.ltP.
     by []. by rewrite /x0 repeat_length.
 }
-rewrite rev_length combine_length !length_veclist Nat.min_id in Hlen.
+rewrite length_rev length_combine !length_veclist Nat.min_id in Hlen.
 specialize (H3 (BMULT
                   (nth (n.+1.-1 - @inord n k)
                      (vec_to_list_float n.+1 (A1_J A'))
@@ -4709,7 +4713,7 @@ rewrite nth_vec_to_list_float in H3.
 rewrite mxE in H3.
 apply Bminus_bplus_opp_implies in H3.
 rewrite rev_nth in Hnth.
-rewrite combine_length !length_veclist Nat.min_id in Hnth.
+rewrite length_combine !length_veclist Nat.min_id in Hnth.
 rewrite combine_nth in Hnth.
 assert ((n.+1 - k.+1)%coq_nat = (n.+1.-1 - k)%coq_nat) by lia.
 rewrite H5 in Hnth.
@@ -4737,7 +4741,7 @@ apply H3.
 by apply /ssrnat.ltP.
 by apply /ssrnat.ltP.
 by rewrite !length_veclist.
-by rewrite combine_length !length_veclist Nat.min_id.
+by rewrite length_combine !length_veclist Nat.min_id.
 by apply /ssrnat.ltP.
 by apply /ssrnat.ltP.
 rewrite inordK; by apply /ssrnat.ltP.
@@ -4783,13 +4787,13 @@ pose proof (@In_nth _ (rev
 specialize (H4 H2).
 destruct H4 as [k [Hlen Hnth]].
 assert (Hrlen: length (resid (jacobi_n A b x0 0)) = n.+1).
-{ repeat rewrite /matrix_vector_mult !map_length combine_length.
-    rewrite !map_length. unfold jacobi_n. rewrite iter_length.
-    rewrite !seq_length /matrix_rows_nat H0 !Nat.min_id.
+{ repeat rewrite /matrix_vector_mult !length_map length_combine.
+    rewrite !length_map. unfold jacobi_n. rewrite iter_length.
+    rewrite !length_seq /matrix_rows_nat H0 !Nat.min_id.
     rewrite /n prednK. by []. by apply /ssrnat.ltP.
     by []. by rewrite /x0 repeat_length.
 }
-rewrite rev_length combine_length !length_veclist Nat.min_id in Hlen.
+rewrite length_rev length_combine !length_veclist Nat.min_id in Hlen.
 specialize (H3 (BMULT
                   (nth (n.+1.-1 - i)
                      (vec_to_list_float n.+1 (A1_J A'))
@@ -4849,7 +4853,7 @@ assert (In
 }
 specialize (H3 H4).
 rewrite rev_nth in Hnth.
-rewrite combine_length !length_veclist Nat.min_id in Hnth.
+rewrite length_combine !length_veclist Nat.min_id in Hnth.
 apply BMULT_finite_e in H3.
 destruct H3 as [_ H3].
 rewrite nth_vec_to_list_float in H3.
@@ -4902,7 +4906,7 @@ apply H5.
 by rewrite !length_veclist.
 apply ltn_ord.
 apply ltn_ord.
-by rewrite combine_length !length_veclist Nat.min_id.
+by rewrite length_combine !length_veclist Nat.min_id.
 Qed.
 
 
@@ -4936,9 +4940,9 @@ specialize (H2 (rev (resid (jacobi_n A b x0 0)))).
 rewrite rev_involutive in H2.
 specialize (H2 H1). 
 assert (Hrlen: length (resid (jacobi_n A b x0 0)) = n.+1).
-{ repeat rewrite /matrix_vector_mult !map_length combine_length.
-    rewrite !map_length. unfold jacobi_n. rewrite iter_length.
-    rewrite !seq_length /matrix_rows_nat H0 !Nat.min_id.
+{ repeat rewrite /matrix_vector_mult !length_map length_combine.
+    rewrite !length_map. unfold jacobi_n. rewrite iter_length.
+    rewrite !length_seq /matrix_rows_nat H0 !Nat.min_id.
     rewrite /n prednK. by []. by apply /ssrnat.ltP.
     by []. by rewrite /x0 repeat_length.
 }
@@ -5113,7 +5117,8 @@ elim: s i => [ |a s IHs] i.
   by simpl. simpl. apply IHs.
 Qed.
 
-Lemma bigmaxr_cons_0 (a:R) s :
+(* bigmax deprecated, moved to lemmas.v *)
+(* Lemma bigmaxr_cons_0 (a:R) s :
  (forall i : nat,
     (i < size (a :: s))%nat ->
     (0 <= nth i (a :: s) 0)%Re) ->
@@ -5142,10 +5147,10 @@ assert (s = [::] \/ s != [::]).
       simpl in H. apply H. apply H3.
     } specialize (H3 i). rewrite -seq_nth_equiv.
     by apply H3.
-Qed.
+Qed. *)
   
-
-Lemma bigmaxr_eq_0 s:
+(* bigmax deprecated, moved to lemmas.v *)
+(* Lemma bigmaxr_eq_0 s:
   (forall i, (i < size s)%nat -> (0 <= nth i s 0%Re)%Re) -> 
   bigmaxr 0%Re s = 0%Re ->
   (forall i, (i < size s)%nat -> nth i s 0%Re = 0%Re).
@@ -5159,7 +5164,7 @@ elim: s i H H0 H1 => [ |a s IHs] i H H0 H1.
     * apply IHs. intros. specialize (H i0.+1). simpl in H.
       apply H. apply H2. apply H0. apply H1.
   - intros. by apply H.
-Qed.
+Qed. *)
 
 
 Lemma bigsum_eq_0 {n} (f : nat ->R):
@@ -5193,52 +5198,35 @@ Lemma matrix_inf_norm_0_implies {n:nat}:
   matrix_inf_norm A = 0%Re ->
   (forall i j, A i j = 0%Re).
 Proof.
-intros.
-unfold matrix_inf_norm in H.
-pose proof bigmaxr_eq_0.
-specialize (H0 [seq row_sum A i | i <- enum 'I_n.+1]).
-assert (forall i : nat,
-        (i <
-        size
-         [seq row_sum A i0
-            | i0 <- enum
-                    'I_n.+1])%nat ->
-          (0 <=
-           nth i
-             [seq row_sum A i0
-                | i0 <- enum
-                        'I_n.+1] 0)%Re).
-{ intros. rewrite seq_equiv seq_nth_equiv. rewrite nth_mkseq.
-  unfold row_sum. apply /RleP. apply big_ge_0_ex_abstract.
-  intros. apply /RleP. apply Rabs_pos.
-  by rewrite size_map size_enum_ord in H1.
-} specialize (H0 H1 H).
-specialize (H0 i).
-rewrite seq_nth_equiv seq_equiv in H0.
-rewrite nth_mkseq in H0; last by apply ltn_ord.
-unfold row_sum in H0.
-pose proof (@bigsum_eq_0 n.+1). 
-specialize (H2 (fun j => Rabs (A i (@inord n j)))).
-assert (forall i0 : nat,
-        (i0 < n.+1)%nat ->
-        (0 <= (fun j : nat => Rabs (A i (@inord n j))) i0)%Re).
-{ intros. apply Rabs_pos. } specialize (H2 H3).
-assert (\sum_(j < n.+1)
-        (fun j0 : nat => Rabs (A i (@inord n j))) j = 0%Re).
-{ rewrite -H0. apply eq_big. by []. intros. 
-  by rewrite !inord_val. 
-  rewrite size_map. rewrite -val_enum_ord. rewrite size_map size_enum_ord.
-  apply ltn_ord.
-} specialize (H2 H4). clear H3 H4. 
-specialize (H2 j).
-assert ((j < n.+1)%nat). { by apply ltn_ord. }
-specialize (H2 H3). simpl in H2.
-rewrite inord_val in H2.
-assert ((0 <= A i j)%Re \/ (A i j < 0)%Re). nra.
-destruct H4. rewrite Rabs_right in H2; nra.
-rewrite Rabs_left in H2; try nra.
+  rewrite /matrix_inf_norm. intros.
+  pose proof (@bigmax_eq_0_0head [seq row_sum A i | i <- enum 'I_n.+1]).
+  assert (forall i0 : nat, (i0 < size [seq row_sum A i1 | i1 <- enum 'I_n.+1])%N -> 
+    (0 <= seq.nth 0 [seq row_sum A i1 | i1 <- enum 'I_n.+1] i0)%Re).
+  { intros. rewrite size_map size_enum_ord in H1.
+    rewrite (@nth_map _ ord0); last by rewrite size_enum_ord.
+    rewrite /row_sum. apply /RleP. apply big_ge_0_ex_abstract.
+    intros. apply /RleP. apply Rabs_pos. }
+  specialize (H0 H1 H). clear H1.
+  pose proof (@bigsum_eq_0 n.+1 (fun j => Rabs (A i (@inord n j)))).
+  assert (forall i0 : nat, (i0 < n.+1)%N -> (0 <= (fun j0 : nat => Rabs (A i (inord j0))) i0)%Re).
+  { intros. apply Rabs_pos. }
+  specialize (H1 H2). clear H2.
+  specialize (H0 i). assert ((i < size [seq row_sum A i0 | i0 <- enum 'I_n.+1])%N).
+  { rewrite size_map size_enum_ord. apply ltn_ord. } 
+  specialize (H0 H2). clear H2.
+  assert (\sum_(j0 < n.+1) (fun j1 : nat => Rabs (A i (inord j1))) j0 = 0%Re).
+  { rewrite (@nth_map _ ord0) in H0; 
+      last by (rewrite size_enum_ord; apply ltn_ord).
+    replace (seq.nth ord0 (enum 'I_n.+1) i) with i in H0
+      by rewrite nth_ord_enum //=.
+    rewrite /row_sum in H0. rewrite -H0.
+    apply eq_big; auto. intros. by rewrite inord_val. }
+  specialize (H1 H2 (nat_of_ord j)).
+  assert (j < n.+1)%N. { apply ltn_ord. }
+  specialize (H1 H3). clear H3. simpl in H1.
+  rewrite inord_val in H1.
+  by apply Rabs_0_implies_0.
 Qed.
-
 
 
 (** entries zero in real ==> entries zero in float **)
@@ -5440,14 +5428,14 @@ assert ((let l1 :=
     assert (forall l l': vector t, (l, l').2 = l').
     { intros. by simpl. } rewrite H13 in H11.
     apply H11. 
-    + rewrite combine_length !length_veclist Nat.min_id.
+    + rewrite length_combine !length_veclist Nat.min_id.
       intros. 
       rewrite nth_vec_to_list_float; last by apply /ssrnat.ltP.
       rewrite mxE. rewrite mxE. 
       apply x_real_to_float_zero.
       by []. rewrite !inord_val. 
       specialize (H9 (@inord n i0)). by rewrite mxE in H9. 
-    + rewrite combine_length !length_veclist Nat.min_id.
+    + rewrite length_combine !length_veclist Nat.min_id.
       intros. rewrite nth_vec_to_list_float; last by apply /ssrnat.ltP.
       by rewrite mxE. 
   } rewrite H11. rewrite Bminus_x_0 .
@@ -5522,14 +5510,14 @@ assert ((let l1 :=
   assert (forall l l': vector t, (l, l').2 = l').
   { intros. by simpl. } rewrite H13 in H11.
   apply H11. intros. 
-  + rewrite combine_length !length_veclist Nat.min_id.
-    rewrite combine_length !length_veclist Nat.min_id in H14.
+  + rewrite length_combine !length_veclist Nat.min_id.
+    rewrite length_combine !length_veclist Nat.min_id in H14.
     rewrite nth_vec_to_list_float; last by apply /ssrnat.ltP.
     rewrite mxE. rewrite mxE. 
     apply x_real_to_float_zero.
     by []. rewrite !inord_val. 
     specialize (H9 (@inord n i0)). by rewrite mxE in H9. 
-  + rewrite combine_length !length_veclist Nat.min_id.
+  + rewrite length_combine !length_veclist Nat.min_id.
     intros. rewrite nth_vec_to_list_float; last by apply /ssrnat.ltP.
     rewrite mxE. 
     assert (jacobi_iter x0' b' A' (@inord n i0) ord0 = X_m_jacobi 1 x0' b' A' (@inord n i0) ord0).
@@ -5562,14 +5550,14 @@ assert ((let l1 :=
   assert (forall l l': vector t, (l, l').2 = l').
   { intros. by simpl. } rewrite H14 in H12.
   apply H12. 
-  + rewrite combine_length !length_veclist Nat.min_id.
+  + rewrite length_combine !length_veclist Nat.min_id.
     intros. 
     rewrite nth_vec_to_list_float; last by apply /ssrnat.ltP.
     rewrite mxE. rewrite mxE. 
     apply x_real_to_float_zero.
     by []. rewrite !inord_val. 
     specialize (H9 (@inord n i0)). by rewrite mxE in H9. 
-  + rewrite combine_length !length_veclist Nat.min_id.
+  + rewrite length_combine !length_veclist Nat.min_id.
     intros. rewrite nth_vec_to_list_float; last by apply /ssrnat.ltP.
     by rewrite mxE. 
 } rewrite H12.
@@ -5729,14 +5717,14 @@ assert ((let l1 :=
   assert (forall l l': vector t, (l, l').2 = l').
   { intros. by simpl. } rewrite H13 in H11.
   apply H11. intros. 
-  + rewrite combine_length !length_veclist Nat.min_id.
-    rewrite combine_length !length_veclist Nat.min_id in H14.
+  + rewrite length_combine !length_veclist Nat.min_id.
+    rewrite length_combine !length_veclist Nat.min_id in H14.
     rewrite nth_vec_to_list_float; last by apply /ssrnat.ltP.
     rewrite mxE. rewrite mxE. 
     apply x_real_to_float_zero.
     by []. rewrite !inord_val. 
     specialize (H9 (@inord n i0)). by rewrite mxE in H9. 
-  + rewrite combine_length !length_veclist Nat.min_id.
+  + rewrite length_combine !length_veclist Nat.min_id.
     intros. rewrite nth_vec_to_list_float; last by apply /ssrnat.ltP.
     rewrite mxE.
     assert (jacobi_iter x0' b' A' (@inord n i0) ord0 = X_m_jacobi 1 x0' b' A' (@inord n i0) ord0).
@@ -5838,14 +5826,14 @@ apply Bplus_no_ov_finite.
     assert (forall l l': vector t, (l, l').2 = l').
     { intros. by simpl. } rewrite H15 in H13.
     apply H13. intros. 
-    + rewrite combine_length !length_veclist Nat.min_id.
-      rewrite combine_length !length_veclist Nat.min_id in H16.
+    + rewrite length_combine !length_veclist Nat.min_id.
+      rewrite length_combine !length_veclist Nat.min_id in H16.
       rewrite nth_vec_to_list_float; last by apply /ssrnat.ltP.
       rewrite mxE. rewrite mxE. 
       apply x_real_to_float_zero.
       by []. rewrite !inord_val. 
       specialize (H11 (@inord n i0)). by rewrite mxE in H11. 
-    + rewrite combine_length !length_veclist Nat.min_id.
+    + rewrite length_combine !length_veclist Nat.min_id.
       intros. rewrite nth_vec_to_list_float; last by apply /ssrnat.ltP.
       rewrite mxE. 
       assert (jacobi_iter x0' b' A' (@inord n i0) ord0 = X_m_jacobi 1 x0' b' A' (@inord n i0) ord0).
@@ -5878,14 +5866,14 @@ apply Bplus_no_ov_finite.
     assert (forall l l': vector t, (l, l').2 = l').
     { intros. by simpl. } rewrite H16 in H14.
     apply H14. 
-    + rewrite combine_length !length_veclist Nat.min_id.
+    + rewrite length_combine !length_veclist Nat.min_id.
       intros. 
       rewrite nth_vec_to_list_float; last by apply /ssrnat.ltP.
       rewrite mxE. rewrite mxE. 
       apply x_real_to_float_zero.
       by []. rewrite !inord_val. 
       specialize (H11 (@inord n i0)). by rewrite mxE in H11. 
-    + rewrite combine_length !length_veclist Nat.min_id.
+    + rewrite length_combine !length_veclist Nat.min_id.
       intros. rewrite nth_vec_to_list_float; last by apply /ssrnat.ltP.
       by rewrite mxE. 
   } rewrite H14.
@@ -5960,29 +5948,21 @@ Lemma vec_norm_resid_N_0 {t: FPStdLib.type} :
        (X_m_jacobi 2 x0' b' A' -f
         X_m_jacobi 1 x0' b' A')) = 0%Re.
 Proof.
-intros.
-unfold vec_inf_norm.
-apply bigmaxrP.
-split.
-+ assert (seq.nth 0%Re [seq Rabs
-                         (FT2R_mat
-                            (X_m_jacobi 2 x0'
-                               b' A' -f
-                             X_m_jacobi 1 x0'
-                               b' A') i 0)
-                     | i <- enum 'I_n.+1] 0%nat = 0%Re).
-  { rewrite seq_equiv. rewrite nth_mkseq; last by [].
-    rewrite mxE. rewrite resid_sub_0_N_0; try by [].
-    by rewrite Rabs_R0. 
-  } rewrite -H9. apply mem_nth.
-  by rewrite size_map size_enum_ord.
-+ intros. 
-  rewrite size_map size_enum_ord in H9.
-  rewrite seq_equiv. rewrite nth_mkseq; last by apply H9.
-  rewrite mxE. rewrite resid_sub_0_N_0; try by [].
-  rewrite Rabs_R0. apply /RleP. apply Rle_refl.
+  intros. rewrite /vec_inf_norm.
+  apply bigmaxP_0head.
+  { by rewrite size_map size_enum_ord. }
+  { intros.
+    rewrite size_map size_enum_ord in H9.
+    rewrite seq_equiv nth_mkseq; last by apply H9.
+    rewrite mxE resid_sub_0_N_0; auto.
+    rewrite Rabs_R0. apply /RleP. auto. }
+  { intros. move /mapP in H9. destruct H9 as [i0 H9 H10].
+    rewrite H10. apply /RleP. apply Rabs_pos. }
+  { apply /mapP. exists ord0. 
+    unfold enum. apply /mapP. exists ord0; auto.
+    rewrite mxE. rewrite resid_sub_0_N_0; auto.
+    by rewrite Rabs_R0. }
 Qed.
-
 
 
 
@@ -6009,9 +5989,9 @@ Proof.
 intros ? ? ? ? ? ? ? ? ? ? ? HfA2 Hfx0 Hinp HfA HfA1_inv Hfb HN0.
 unfold norm2. 
 assert ( length (resid (jacobi_n A b x0 1%nat)) = n.+1).
-{ repeat rewrite /matrix_vector_mult !map_length combine_length.
-    rewrite !map_length. unfold jacobi_n. (*rewrite iter_length. *)
-    rewrite !seq_length /matrix_rows_nat H0 !Nat.min_id.
+{ repeat rewrite /matrix_vector_mult !length_map length_combine.
+    rewrite !length_map. unfold jacobi_n. (*rewrite iter_length. *)
+    rewrite !length_seq /matrix_rows_nat H0 !Nat.min_id.
     rewrite -/n prednK. by []. by apply /ssrnat.ltP.
     (*by []. by rewrite /x0 repeat_length. *)
 }
@@ -6053,7 +6033,7 @@ apply dotprod_finite.
                    (inord k) ord0))).
   { apply finite_A_mult_x2_minus_x1; try by []. }
   specialize (H7 H8).
-  split; try apply H8. rewrite rev_length H2.
+  split; try apply H8. rewrite length_rev H2.
   intros. rewrite /n0.
   destruct H7 as [d [e [Hde [Hd [He H7]]]]].
   rewrite H7.
@@ -6184,9 +6164,9 @@ destruct H0.
             remember (length A).-1 as n.
             specialize (H5 (resid (jacobi_n A b x0 1%nat)) n).
             assert (length (resid (jacobi_n A b x0 1%nat)) = n.+1).
-            { repeat rewrite /matrix_vector_mult !map_length combine_length.
-              rewrite !map_length. unfold jacobi_n. 
-              rewrite !seq_length /matrix_rows_nat -HeqAb !Nat.min_id.
+            { repeat rewrite /matrix_vector_mult !length_map length_combine.
+              rewrite !length_map. unfold jacobi_n. 
+              rewrite !length_seq /matrix_rows_nat -HeqAb !Nat.min_id.
               rewrite Heqn prednK. by []. by apply /ssrnat.ltP.
             } specialize (H5 H6).
             rewrite H5.
@@ -6255,8 +6235,8 @@ destruct H0.
                                                   (jacobi_n A b x0
                                                     1)) n.+1)))) xy (Zconst t 0, Zconst t 0)).
                 specialize (H10 H9). destruct H10 as [m [Hlenm Hmth]].
-                rewrite rev_length combine_length !length_veclist Nat.min_id in Hlenm.
-                rewrite rev_nth combine_length !length_veclist Nat.min_id in Hmth.
+                rewrite length_rev length_combine !length_veclist Nat.min_id in Hlenm.
+                rewrite rev_nth length_combine !length_veclist Nat.min_id in Hmth.
                 assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat) by lia.
                 rewrite H10 combine_nth in Hmth. 
                 rewrite nth_vec_to_list_float in Hmth; try by [].
@@ -6364,8 +6344,8 @@ destruct H0.
                                                   X_m_jacobi 1 x0' b' A')))) xy (Zconst t 0 , Zconst t 0)).
                   specialize (H12 H11).
                   destruct H12 as [m [Hmth H12]].
-                  rewrite rev_length combine_length !length_veclist Nat.min_id in Hmth.
-                  rewrite rev_nth combine_length !length_veclist Nat.min_id in H12.
+                  rewrite length_rev length_combine !length_veclist Nat.min_id in Hmth.
+                  rewrite rev_nth length_combine !length_veclist Nat.min_id in H12.
                   assert ((n.+1 - m.+1)%coq_nat = (n.+1.-1 - m)%coq_nat) by lia.
                   rewrite H13 in H12.
                   rewrite combine_nth in H12.
@@ -6625,9 +6605,9 @@ destruct H0.
                 pose proof (@v_equiv t).
                 specialize (H6 (resid (jacobi_n A b x0 0)) n).
                 assert (length (resid (jacobi_n A b x0 0)) = n.+1).
-                { repeat rewrite /matrix_vector_mult !map_length combine_length.
-                  rewrite !map_length. unfold jacobi_n. rewrite iter_length.
-                  rewrite !seq_length /matrix_rows_nat -HeqAb !Nat.min_id.
+                { repeat rewrite /matrix_vector_mult !length_map length_combine.
+                  rewrite !length_map. unfold jacobi_n. rewrite iter_length.
+                  rewrite !length_seq /matrix_rows_nat -HeqAb !Nat.min_id.
                   rewrite Heqn prednK. by []. by apply /ssrnat.ltP.
                   by []. by rewrite /x0 repeat_length.
                 } specialize (H6 H7).
@@ -7117,7 +7097,21 @@ destruct H0.
                    apply Rplus_le_le_0_compat. nra. apply g_pos.
                    destruct H as [HfA [Hrho [HinvA [Hfbdiv [HG [Hfacc [Hk [He0 [HfA2 [Hfb [size_cons Hinp]]]]]]]]]]]. 
                    assert (vec_inf_norm (FT2R_mat x0') = 0%Re).
-                   { unfold vec_inf_norm. apply bigmaxrP.
+                   { clear HG H10 H11.
+                     unfold vec_inf_norm. apply bigmaxP_0head.
+                     + by rewrite size_map size_enum_ord.
+                     + intros. rewrite seq_equiv. rewrite nth_mkseq;
+                       last by rewrite size_map size_enum_ord in H.
+                       rewrite Heqx0'. rewrite !mxE /=. rewrite inordK; 
+                       last by rewrite size_map size_enum_ord in H.
+                       unfold x0. rewrite nth_repeat. simpl. rewrite Rabs_R0. apply Rle_refl.
+                     + intros. move /mapP in H. destruct H as [i100 H99 H100].
+                       rewrite H100. apply /RleP. apply Rabs_pos.
+                     + apply /mapP. exists ord0.
+                       unfold enum. apply /mapP. exists ord0; auto.
+                       rewrite Heqx0' !mxE //=. unfold x0. rewrite nth_repeat //=.
+                       by rewrite Rabs_R0.
+                    (* unfold vec_inf_norm. apply bigmaxrP.
                      split.
                      + assert (seq.nth 0%Re [seq Rabs (FT2R_mat x0' i 0)
                                                 | i <- enum 'I_n.+1] 0%nat = 0%Re).
@@ -7130,7 +7124,7 @@ destruct H0.
                        rewrite Heqx0'. rewrite !mxE /=. rewrite inordK; 
                        last by rewrite size_map size_enum_ord in H.
                        unfold x0. rewrite nth_repeat. simpl. rewrite Rabs_R0.
-                       apply /RleP. apply Rle_refl.
+                       apply /RleP. apply Rle_refl. *)
                    } rewrite H. rewrite  !Rmult_0_r !Rmult_0_l ?Rplus_0_r ?Rplus_0_l.
                    (** use : Heqx : x = A_real^-1 *m b_real **)
                    assert (b_real = A_real *m x).

--- a/lemmas.v
+++ b/lemmas.v
@@ -425,6 +425,19 @@ Proof.
   intros. apply /RleP. apply lerD; by apply /RleP.
 Qed. 
 
+Lemma sum_le_all_elements {n : nat} (f1 f2 : 'I_n.+1 -> R) :
+  (forall i, (f1 i <= f2 i)) ->
+  \sum_i f1 i <= \sum_i f2 i.
+Proof.
+  induction n as [|n']; intros.
+  + rewrite //= !big_ord_recr //= !big_ord0 !add0r //=. 
+  + rewrite big_ord_recr //=. 
+    assert (\sum_(i < n'.+2)  f2 i = \sum_(i < n'.+1) f2 (widen_ord (leqnSn n'.+1) i) + f2 ord_max).
+    { rewrite big_ord_recr //=. } rewrite {}H0.
+    apply /RleP. apply Rplus_le_compat; auto.
+    apply /RleP. apply IHn'; auto. apply /RleP. apply H.
+Qed.
+
 Lemma Rabs_ineq {n:nat} (f : 'I_n.+1 -> R):
   Rabs (\sum_j f j) <= \sum_j (Rabs (f j)).
 Proof.
@@ -485,6 +498,13 @@ Proof.
     { rewrite big_ord_recr //=. } rewrite {}H0.
     apply /RleP. apply Rplus_le_compat; auto.
     apply /RleP. apply IHn'; auto.
+Qed.
+
+Lemma sum_all_terms_eq_nat {n : nat} (f1 f2 : nat -> R) :
+  (forall i, (i < n)%N -> f1 i = f2 i) ->
+  \sum_(i < n) f1 i = \sum_(j < n) f2 j.
+Proof.
+  intros. apply eq_big; auto.
 Qed.
 
 (* Lemma bigmax_form_eq (x0 : R) lr :

--- a/lemmas.v
+++ b/lemmas.v
@@ -69,24 +69,22 @@ Qed.
 Lemma m_ge_n (m n :nat) :
   (m <= n)%N -> (m%:R <= n%:R)%Re.
 Proof.
-intros. induction n.
-+ rewrite leqn0 in H. assert ( m = 0%N). { by apply /eqP. }
-  rewrite H0. nra.
+intros. generalize dependent m. induction n; intros.
++ rewrite leqn0 in H. assert (m = 0%N). { apply /eqP; auto. }
+  rewrite H0. apply Rle_refl.
 + rewrite leq_eqVlt in H.
   assert ( (m == n.+1) \/ (m < n.+1)%N).
-  { by apply /orP. } destruct H0.
-  - assert ( m = n.+1). { by apply /eqP. }
-    rewrite H1. nra.
-  - assert ( (m <=n)%N). { by []. }
-    specialize (IHn H1).
-    rewrite -addn1 natrD. apply Rle_trans with n%:R.
-    * apply IHn.
-    * rewrite -RplusE. 
-      assert (n%:R = (n%:R + 0)%Re). { nra. }
-      rewrite H2. 
-      assert ((n%:R + 0 + 1%:R)%Re = (n%:R + 1%:R)%Re).
-      { nra. } rewrite H3. apply Rplus_le_compat. 
-      nra. apply Rlt_le. apply Rlt_0_1. 
+  { apply /orP; auto. }
+  destruct H0.
+  - assert (m = n.+1). { apply /eqP; auto. }
+    rewrite H1. apply Rle_refl.
+  - assert ((m <= n)%N). { auto. }
+    pose proof (IHn m H1).
+    rewrite -addn1 natrD -RplusE. 
+    apply Rle_trans with n%:R; auto.
+    replace n%:R with (n%:R + 0%Ri)%Re at 1.
+    2:{ rewrite Rplus_0_r. auto. }
+    apply Rplus_le_compat_l. apply Rle_0_1.
 Qed.
 
 
@@ -105,12 +103,23 @@ Qed.
 
 Definition row_sum {n:nat} (A: 'M[R]_n) (i: 'I_n) :=
   \big[+%R/0]_(j<n) Rabs (A i j).
-  
 
 
-Definition theta_x {n:nat} (x1 : 'cV[R]_n) (x2 : nat -> 'cV[R]_n) (m:nat) :=
+(* Definition theta_x {n : nat} (x1 : 'cV[R]_n) (x2 : nat -> 'cV[R]_n) (m : nat) :=
+  Lub_Rbar (fun x =>
+    x = \big[Order.Def.max/0]_(i<-enum 'I_n) (Rabs (x2 m i 0) / Rabs (x1 i 0))). *)
+
+Definition theta_x {n : nat} (x1 : 'cV[R]_n) (x2 : nat -> 'cV[R]_n) (m : nat) :=
+  Lub_Rbar (fun x => x = 
+    let s := [seq (Rabs (x2 m i 0) / Rabs (x1 i 0)) | i <- enum 'I_n] in 
+    \big[maxr / head 0%Re s]_(i <- s) i).
+
+
+(* bigmaxr deprecated *)
+(* Definition theta_x {n:nat} (x1 : 'cV[R]_n) (x2 : nat -> 'cV[R]_n) (m:nat) :=
   Lub_Rbar (fun x => 
-    x = bigmaxr 0 [seq (Rabs (x2 m i 0) / Rabs (x1 i 0)) | i <- enum 'I_n]). 
+    x = bigmaxr 0 [seq (Rabs (x2 m i 0) / Rabs (x1 i 0)) | i <- enum 'I_n]). *)
+ 
 
 
 
@@ -133,7 +142,8 @@ Lemma x_minus_x_is_0 {n:nat}:
   forall x: 'cV[R]_n, x - x = 0.
 Proof.
 intros. apply matrixP. unfold eqrel.
-intros. rewrite !mxE //=. apply /eqP.
+intros. 
+rewrite !mxE //=. apply /eqP.
 by rewrite subr_eq0.
 Qed.
 
@@ -151,10 +161,110 @@ assert ([seq Rabs ((GRing.zero : 'cV[R]_n) i0 0) | i0 <- enum 'I_n] =
 } rewrite H0. by rewrite nth_mkseq.
 Qed.
 
+(* bigmax_le exists in mathcomp.analysis.order *)
+Check bigmax_le.
+
+(* bigmaxr deprecated *)
 
 
+Lemma bigmax_mem_0head  (lr : seq R) :
+  (0 < size lr)%N ->
+  (forall x, x \in lr -> x >= 0) ->
+  (\big[maxr/0%Re]_(i <- lr) i) \in lr.
+Proof.
+  induction lr as [|x lr']; intros.
+  + inversion H.
+  + rewrite big_cons. remember (\big[maxr/0%Re]_(j <- lr')  j) as maxlr'.
+    assert (maxr x (\big[maxr/0%Re]_(j <- lr')  j) = maxr x maxlr').
+    { rewrite Heqmaxlr'. auto. } rewrite H1.
+    rewrite /maxr. destruct (x < maxlr') eqn:E.
+    2:{ apply mem_head. }
+    destruct (size lr') eqn : Esize.
+    - destruct lr'. 2:{ inversion Esize. } 
+      subst maxlr'. rewrite big_nil in E. 
+      assert (0 <= x).
+      { apply H0. apply mem_head. }
+      move /RltP in E. move /RleP in H2. 
+      apply Rlt_not_le in H2; auto.
+    - assert (maxlr' \in lr').
+      { apply IHlr'. auto. intros. apply H0. rewrite in_cons. apply /orP. auto. }
+      rewrite in_cons. apply /orP. auto.
+Qed.
 
-Lemma bigmax_le (x0:R) lr (x:R):
+Lemma bigmax_le_0head lr (x:R):
+  (0 < size lr)%N ->
+  (forall i:nat, (i < size lr)%N -> ((nth (0%Re) lr i) <= x)%Re) ->
+  (forall x, x \in lr -> x >= 0) ->
+  (\big[maxr/0%Re]_(i <- lr) i <= x)%Re.
+Proof.
+  intros.
+  pose proof (@bigmax_mem_0head lr H H1).
+  move /(nthP 0%Re): H2.
+  move => [i i_size <-].
+  by apply H0.
+Qed.
+
+Lemma maxr_l (x y : R) : x <= maxr x y.
+Proof.
+  rewrite /maxr. destruct (x < y) eqn:E; auto.
+Qed.
+
+Lemma maxr_r (x y : R) : y <= maxr x y.
+Proof. 
+  rewrite maxC. apply maxr_l.
+Qed.
+
+Lemma maxr_l_le (x y z : R) : x <= y -> x <= maxr y z.
+Proof.
+  intros. rewrite /maxr. destruct (y < z) eqn:E; auto.
+  assert (y < z) by auto. 
+  apply /RleP. move /RltP in H0. move /RleP in H.
+  apply Rlt_le in H0. nra.
+Qed.
+
+Lemma maxr_r_le (x y z : R) : x <= z -> x <= maxr y z.
+Proof.
+  intros. rewrite maxC. apply maxr_l_le; auto.
+Qed.
+
+Lemma bigmax_ler_0head lr (x:R):
+  x \in lr ->
+  (forall x, x \in lr -> x >= 0) ->
+  (x <= \big[maxr/0%Re]_(i <- lr) i)%Re.
+Proof.
+  intros. induction lr as [|y lr'].
+  + inversion H.
+  + rewrite in_cons in H. move /orP in H. destruct H.
+    - move /eqP in H. rewrite H. rewrite big_cons. apply /RleP. apply maxr_l.
+    - rewrite big_cons. apply /RleP. apply maxr_r_le. apply /RleP. apply IHlr'; auto.
+      intros. apply H0. rewrite in_cons. apply /orP. auto.
+Qed.
+
+Lemma bigmax_mulr_0head lr (k : R) :
+  let klr := [seq (k * x) | x <- lr] in
+  (0 < size lr)%N ->
+  (forall x, x \in lr -> x >= 0) ->
+  (k >= 0) ->
+  (k * (\big[maxr/0%Re]_(i <- lr) i) = \big[maxr/0%Re]_(i <- klr) i)%Re.
+Proof.
+  intros. induction lr as [|x lr']; [inversion H|].
+  remember [seq k * x | x <- lr'] as klr'.
+  assert (klr = (k * x) :: klr').
+  { subst klr klr'. rewrite //=. } 
+  rewrite H2. rewrite big_cons big_cons. rewrite //= in IHlr'.
+  rewrite RmultE. rewrite maxr_pMr; auto.
+  assert (k * \big[maxr/0%Re]_(j <- lr')  j =
+    \big[maxr/0%Re]_(j <- klr')  j).
+  { destruct (size lr') eqn:E.
+    + apply size0nil in E. subst lr' klr'. rewrite !big_nil //=.
+      rewrite -RmultE. nra.
+    + apply IHlr'.
+      { rewrite E //=. }
+      intros. apply H0. rewrite in_cons. apply /orP. auto. } 
+  rewrite H3. reflexivity.
+Qed.   
+
+(* Lemma bigmax_le_deprecated (x0:R) lr (x:R):
  (0 < size lr)%N ->
  (forall i:nat, (i < size lr)%N -> ((nth x0 lr i) <= x)%Re) ->
  ((bigmaxr x0 lr) <= x)%Re.
@@ -163,17 +273,16 @@ intros.
 move /(nthP x0): (bigmaxr_mem x0 H).
 move => [i i_size <-].
 by apply H0.
-Qed.
-
+Qed. *)
 
 
 Lemma enum_list:
   enum 'I_3 = [:: ord0;  1; (@inord 2 2)].
 Proof.
-apply: (inj_map val_inj); rewrite val_enum_ord.
-rewrite /iota //=.
-assert ((1 %% 3)%N = 1%N). { by []. } rewrite H //=.
-by rewrite inordK.
+  apply (inj_map val_inj). rewrite val_enum_ord.
+  rewrite /iota. simpl.
+  assert ((1 %% 3) = 1)%N. { auto. } rewrite H.
+  rewrite inordK; auto.
 Qed.
 
 
@@ -189,7 +298,40 @@ induction s.
 + by intros. 
 Qed.
   
-Lemma bigmax_le_0 (x0:R) s:
+
+Lemma bigmax_le_0 (x0 : R) s :
+  0 <= x0 ->
+  (forall i, (i < size s)%N -> 0 <= nth x0 s i) ->
+  0 <= \big[Order.Def.max / head x0 s]_(i <- s) i.
+  (* 0 <= \big[Order.Def.max / x0]_(i <- enum 'I_(size s)) (nth x0 s i). *)
+Proof.
+  intros. induction s as [|s0 s'].
+  + rewrite //= big_nil. exact H.
+  + rewrite //= big_cons //=.
+    destruct s' as [| s1 s'].
+    - rewrite big_nil. specialize (H0 0). simpl in H0.
+      replace (maxr s0 s0) with s0.
+      apply H0. auto. rewrite /maxr. replace (s0 < s0) with false; auto. 
+    - rewrite le_max. apply /orP.
+      pose proof (H0 0). rewrite //= in H1. left. by apply H1.
+Qed.
+
+Lemma bigmax_le_0_0head s :
+  (forall i, (i < size s)%N -> 0 <= nth 0 s i) ->
+  0 <= \big[maxr/0%Re]_(i <- s) i.
+Proof.
+  intros. induction s as [|s0 s'].
+  + rewrite //= big_nil. apply /RleP. apply Rle_refl.
+  + rewrite //= big_cons //=.
+    destruct s' as [| s1 s'].
+    - rewrite big_nil. apply maxr_r. 
+    - rewrite le_max. apply /orP.
+      right. apply IHs'. intros. 
+      pose proof (H i.+1). apply H1. rewrite //=.
+Qed.
+
+(* bigmaxr deprecated *)
+(* Lemma bigmax_le_0_deprecated (x0:R) s:
   0 <= x0 ->
   (forall i, (i < size s)%N -> 0 <= nth x0 s i) ->
   0 <= bigmaxr x0 s.
@@ -216,20 +358,16 @@ induction s.
     rewrite le_max. apply /orP.
     specialize (H0 0%N). simpl in H0.
     left. by apply H0. 
-Qed.
+Qed. *)
+
 
 
 Lemma big_ge_0_ex_abstract I r (P: pred I) (E : I -> R):
   (forall i, P i -> (0 <= E i)) ->
   (0 <= \big[+%R/0]_(i <-r | P i) E i).
 Proof.
-move => leE. apply big_ind.
-+ apply /RleP. apply Rle_refl.
-+ intros. apply /RleP.
-  rewrite -RplusE. apply Rplus_le_le_0_compat.  
-  - by apply /RleP.
-  - by apply /RleP.
-+ apply leE.
+  intros. apply big_ind; auto.
+  intros. apply /RleP. apply Rplus_le_le_0_compat; apply /RleP; auto.
 Qed.
 
 
@@ -237,31 +375,41 @@ Lemma big_sum_ge_ex_abstract I r (P: pred I) (E1 E2: I -> R):
   (forall i, P i -> (E1 i <= E2 i)%Re) ->
   (\big[+%R/0]_(i <-r | P i) E1 i <= \big[+%R/0]_(i <-r | P i) E2 i).
 Proof.
-move => leE12. apply /RleP. apply big_ind2.
-+ nra.
-+ intros. rewrite -!RplusE. by apply Rplus_le_compat.
-+ apply leE12.
-Qed.
+  intros. apply /RleP. apply big_ind2; auto; try lra.
+  intros. apply /RleP. apply lerD; by apply /RleP.
+Qed. 
 
 Lemma Rabs_ineq {n:nat} (f : 'I_n.+1 -> R):
   Rabs (\sum_j f j) <= \sum_j (Rabs (f j)).
 Proof.
-induction n.
-+ simpl. rewrite !big_ord_recr //= !big_ord0 !add0r //=.
-+ simpl. rewrite big_ord_recr //=.
-  assert (\sum_(j < n.+2) Rabs (f j) = 
-            \sum_(j < n.+1) Rabs (f (widen_ord (leqnSn n.+1) j)) + Rabs (f ord_max)).
-  { by rewrite !big_ord_recr//=. } rewrite H. 
-  apply /RleP. rewrite -!RplusE.
-  apply Rle_trans with 
-  (Rabs (\sum_(i < n.+1) f (widen_ord (leqnSn n.+1) i)) +
-    Rabs (f ord_max))%Re.
-  - apply Rabs_triang.
-  - apply Rplus_le_compat_r. apply /RleP. by apply IHn.
+  induction n as [|n'].
+  + rewrite //= !big_ord_recr //= !big_ord0 !add0r //=.
+  + rewrite //= big_ord_recr //=.
+    assert ((\sum_(j < n'.+2) Rabs (f j)) 
+      = (\sum_(j < n'.+1) Rabs (f (widen_ord (leqnSn n'.+1) j)) + Rabs (f ord_max)))
+      by rewrite //= !big_ord_recr //=.
+    rewrite H. apply /RleP. 
+    eapply Rle_trans. { apply Rabs_triang. }
+    apply Rplus_le_compat_r. apply /RleP. apply IHn'.
 Qed.
-  
 
+Lemma sum_mult_distrl {n : nat} (x : R) (f : 'I_n.+1 -> R) :
+  \sum_(i < n.+1) (x * f i) = x * (\sum_(i < n.+1) f i).
+Proof.
+  induction n as [|n'].
+  + rewrite !big_ord_recr //= !big_ord0 !add0r //=.
+  + rewrite big_ord_recr //= IHn' [in RHS]big_ord_recr //=.
+    rewrite -!RplusE -!RmultE. rewrite Rmult_plus_distr_l //=.
+Qed.
 
+Lemma sum_mult_distrr {n : nat} (x : R) (f : 'I_n.+1 -> R) :
+  \sum_(i < n.+1) (f i * x) = (\sum_(i < n.+1) f i) * x. 
+Proof.
+  induction n as [|n'].
+  + rewrite !big_ord_recr //= !big_ord0 !add0r //=.
+  + rewrite big_ord_recr //= IHn' [in RHS]big_ord_recr //=.
+    rewrite -!RplusE -!RmultE. rewrite Rmult_plus_distr_r //=.
+Qed.
 
 
 Lemma seq_equiv {n:nat} (f : 'I_n.+1 -> R) :
@@ -274,10 +422,66 @@ apply eq_map. unfold eqfun. intros.
 by rewrite //= inord_val //=.
 Qed.
 
+Lemma seq_sum_mult_distrl {n : nat} (x : R) (f : 'I_n.+1 -> R) :
+  [seq x * i | i <- [seq f i | i <- enum 'I_n.+1]] = [seq x * f i | i <- enum 'I_n.+1].
+Proof.
+  induction n as [|n']; rewrite -map_comp //=.
+Qed. 
+
+Lemma sum_all_terms_le {n : nat} (f1 f2 : 'I_n.+1 -> R) :
+  (forall i, (f1 i <= f2 i)%Re) ->
+  \sum_(i < n.+1) f1 i <= \sum_(i < n.+1) f2 i.
+Proof.
+  induction n as [|n']; intros.
+  + rewrite !big_ord_recr //= !big_ord0 //= !add0r. apply /RleP. apply H.
+  + rewrite big_ord_recr //=. 
+    assert (\sum_(i < n'.+2)  f2 i = \sum_(i < n'.+1) f2 (widen_ord (leqnSn n'.+1) i) + f2 ord_max).
+    { rewrite big_ord_recr //=. } rewrite {}H0.
+    apply /RleP. apply Rplus_le_compat; auto.
+    apply /RleP. apply IHn'; auto.
+Qed.
+
+(* Lemma bigmax_form_eq (x0 : R) lr :
+  (0 < size lr)%N ->
+  \big[Order.Def.max / head x0 lr]_(i <- lr) i = 
+  \big[Order.Def.max / head x0 lr]_(i <- enum 'I_(size lr)) nth x0 lr i.
+Proof.
+  intros. induction lr as [|x lr'].
+  + inversion H.
+  + rewrite //=. destruct lr' as [|y lr'].
+    - simpl. rewrite big_cons big_nil big_enum //=. admit.
+    - simpl. rewrite big_cons. 
+ *)
+
+Lemma bigmax_seq_idx_eq (x0 : R) lr :
+  \big[Order.Def.max/x0]_(i <- lr) i = \big[Order.Def.max/x0]_(i < (size lr)) nth x0 lr i.
+Proof.
+  induction lr as [|x lr'].
+  + rewrite big_ord0 big_nil //.
+  + rewrite //= big_cons big_ord_recl //= IHlr' //=.
+Qed.
 
 
+Lemma bigmax_le_implies (x0 : R) lr (x : R):
+  (0 < size lr) %N ->
+  (\big[Order.Def.max / x0]_(i <- lr) i <= x)%Re ->
+  (forall i : nat, (i < size lr)%N -> ((nth x0 lr i) <= x)%Re).
+Proof.
+  intros. apply Rle_trans with (\big[Order.Def.max / x0]_(i <- lr) i); auto.
+  apply /RleP. 
+  remember (size lr) as n.
+  destruct n as [| n'].
+  + inversion H1.
+  + pose proof ( @le_bigmax _ _ _ x0 (fun i => nth x0 lr (nat_of_ord i)) (@inord n' i)).
+    rewrite //= in H2.
+    rewrite bigmax_seq_idx_eq -Heqn.
+    replace (nth x0 lr i) with (nth x0 lr (@inord n' i)). apply H2.
+    rewrite inordK; auto.
+Qed.
 
-Lemma bigmax_le_implies (x0:R) lr (x:R):
+
+(* bigmaxr deprecated *)
+(* Lemma bigmax_le_implies_deprecated (x0:R) lr (x:R):
  (0 < size lr)%N ->
   ((bigmaxr x0 lr) <= x)%Re -> 
  (forall i:nat, (i < size lr)%N -> ((nth x0 lr i) <= x)%Re).
@@ -286,9 +490,10 @@ intros.
 apply Rle_trans with (bigmaxr x0 lr).
 + apply /RleP. by apply (@bigmaxr_ler _ x0 lr i).
 + apply H0.
-Qed.
+Qed. *)
 
 
+(* Computes error ^ 0 + error ^ 1 + ... + error ^ (n-1) *)
 Definition error_sum_ind:= 
   fun (error : R) (n : nat) =>
   match n with
@@ -339,26 +544,22 @@ Ltac rewrite_scope :=
 Lemma Rle_minus_l :
   forall a b c : R, (a - b <= c) -> (a <= c + b). 
 Proof.
-intros. rewrite -RplusE.
-rewrite_scope.
-rewrite -RminusE in H.
-assert (a - b <= c)%Re.
-rewrite_scope; auto.
-nra.
+  move => a b c /RleP H. rewrite -RminusE in H.
+  rewrite_scope. rewrite -RplusE.
+  nra.
 Qed.
 
 Lemma mulmx_distrr {n:nat}:
   forall (A :'M[R]_n) (f : nat -> 'cV[R]_n) (k:nat),
   \sum_(i < k.+1) (A *m (f i)) = A *m (\sum_(i < k.+1) (f i)).
 Proof.
-intros. induction k.
-+ rewrite !big_ord_recr //= !big_ord0. by rewrite !add0r.
-+ rewrite big_ord_recr //=.
-  assert (\sum_(i < k.+2) f i = (\sum_(i < k.+1) f i) + f k.+1).
-  { by rewrite !big_ord_recr //= !big_ord0. } rewrite H.
-  rewrite mulmxDr. by rewrite IHk.
+  intros. induction k.
+  + rewrite !big_ord_recr //= !big_ord0 !add0r //=.
+  + rewrite big_ord_recr //= IHk.
+    assert ((\sum_(i < k.+2)  f i) = (\sum_(i < k.+1) f i + f k.+1)).
+    { rewrite big_ord_recr //=. }
+    rewrite H  mulmxDr //=.
 Qed.
-
 
 Lemma two_not_zero:
   2%Re <> 0%Re.
@@ -408,23 +609,17 @@ Qed.
 
 Lemma error_sum_aux2 er n:
   er * error_sum_ind er n + 1  = error_sum_ind er (S n).
-Proof. 
-intros.
-induction n. 
-+ simpl. unfold sum_f. rewrite mulr0 add0r //=. 
-+ unfold error_sum_ind. rewrite /error_sum_ind in IHn.
-  destruct n.
-  - rewrite /sum_f. simpl. rewrite /sum_f in IHn. simpl in IHn.
-    rewrite mulr0 in IHn. rewrite add0r in IHn. rewrite -IHn. 
-    rewrite mulr1. rewrite RplusE //=. 
-    assert (er ^ 1%N = er). { by rewrite //=. } rewrite H.
-    by rewrite addrC.
-  - rewrite /sum_f. rewrite /sum_f in IHn. simpl.
-    assert ( (n + 0)%coq_nat = n). { lia. } rewrite H.
-    rewrite !RplusE. simpl in IHn. rewrite H in IHn.
-    rewrite mulrDr.
-    assert ((n - 0)%coq_nat = n). { lia. } rewrite H0 in IHn.
-    rewrite -!addrA -(addrC 1) !addrA IHn RplusE //.
+Proof.
+  induction n as [|n'].
+  + rewrite //= /sum_f //= mulr0 expr0z add0r //=.
+  + unfold error_sum_ind in *.
+    destruct n' as [|n''].
+    - rewrite /sum_f //= expr0z mulr1 expr1z RplusE addrC //=.
+    - rewrite /sum_f //= -!plus_n_O. 
+      rewrite /sum_f //= -!plus_n_O Nat.sub_0_r in IHn'.
+      rewrite !RplusE. rewrite !RplusE in IHn'.
+      rewrite mulrDr -!addrA (addrC (er * er ^ n''.+1)) addrA IHn'.
+      rewrite addrA -exprS //=.
 Qed.
 
 
@@ -478,28 +673,27 @@ Lemma sum_abs_le {n:nat}:
     \sum_(j < n.+1) Rabs (f j) +
     \sum_(j < n.+1) Rabs (g j))%Re.
 Proof.
-intros. induction n.
-+ rewrite !big_ord_recr //= !big_ord0 !add0r. 
-  apply Rabs_triang.
-+ rewrite big_ord_recr //=. rewrite -RplusE.
-  assert (\sum_(j < n.+2) Rabs (f j) = 
-          \sum_(j < n.+1) Rabs (f (widen_ord (leqnSn n.+1) j)) + Rabs (f ord_max)).
-  { by rewrite big_ord_recr //=. } rewrite H.
-  assert (\sum_(j < n.+2) Rabs (g j) = 
-          \sum_(j < n.+1) Rabs (g (widen_ord (leqnSn n.+1) j)) + Rabs (g ord_max)).
-  { by rewrite big_ord_recr //=. } rewrite H0.
-  rewrite -!RplusE.
-  assert ((\sum_(j < n.+1) Rabs (f (widen_ord (leqnSn n.+1) j)) +
-             Rabs (f ord_max) +
-             (\sum_(j < n.+1) Rabs (g (widen_ord (leqnSn n.+1) j)) +
-              Rabs (g ord_max)))%Re = 
-           ((\sum_(j < n.+1) Rabs (f (widen_ord (leqnSn n.+1) j)) +
-            \sum_(j < n.+1) Rabs (g (widen_ord (leqnSn n.+1) j))) +
-            (Rabs (f ord_max) +  Rabs (g ord_max)))%Re).
-  { nra. } rewrite H1.
-  apply Rplus_le_compat.
-  - apply IHn.
-  - apply Rabs_triang.
+  intros. induction n as [|n'].
+  + rewrite !big_ord_recr //= !big_ord0 !add0r.
+    apply Rabs_triang.
+  + rewrite big_ord_recr //=. 
+    eapply Rle_trans.
+    { eapply (Rplus_le_compat_r). apply IHn'. }
+    assert (\sum_(j < n'.+2)  Rabs (f j) = 
+      \sum_(j < n'.+1)  Rabs ((fun j0 : 'I_n'.+1 => f (widen_ord (leqnSn n'.+1) j0)) j) + Rabs (f ord_max)). 
+    { rewrite big_ord_recr //=. } 
+    assert (\sum_(j < n'.+2)  Rabs (g j) = 
+      \sum_(j < n'.+1)  Rabs ((fun j0 : 'I_n'.+1 => g (widen_ord (leqnSn n'.+1) j0)) j) + Rabs (g ord_max)).
+    { rewrite big_ord_recr //=. }
+    rewrite H H0. clear H H0.
+    rewrite -!RplusE. 
+    remember (\sum_(j < n'.+1)  Rabs (f (widen_ord (leqnSn n'.+1) j))) as S1.
+    remember (\sum_(j < n'.+1)  Rabs (g (widen_ord (leqnSn n'.+1) j))) as S2.
+    remember (f ord_max) as x1.
+    remember (g ord_max) as x2.
+    eapply Rle_trans.
+    { eapply Rplus_le_compat_l. apply Rabs_triang. }
+    lra.
 Qed.
  
 
@@ -507,14 +701,24 @@ Lemma mulmx_distrl {n:nat}:
   forall (A :'cV[R]_n) (f : nat -> 'M[R]_n) (k:nat),
   \sum_(i < k.+1) ((f i) *m A) = (\sum_(i < k.+1) (f i)) *m A.
 Proof.
-intros. induction k.
-+ rewrite !big_ord_recr //= !big_ord0. by rewrite !add0r.
-+ rewrite big_ord_recr //=.
-  assert (\sum_(i < k.+2) f i = (\sum_(i < k.+1) f i) + f k.+1).
-  { by rewrite !big_ord_recr //= !big_ord0. } rewrite H.
-  rewrite mulmxDl. by rewrite IHk.
+  intros. induction k as [|k'].
+  + rewrite !big_ord_recr //= !big_ord0. rewrite !add0r //=.
+  + rewrite big_ord_recr //= IHk'.
+    assert (\sum_(i < k'.+2)  f i = \sum_(i < k'.+1) f i + f k'.+1).
+    { rewrite big_ord_recr //=. } 
+    rewrite H mulmxDl //=.
 Qed.
 
+Lemma sum_of_pos {n : nat} (f : 'I_n.+1 -> R) :
+  (forall i, (0 <= f i)) ->
+  (0 <= \sum_(i < n.+1) f i).
+Proof.
+  intros. induction n as [|n'].
+  + rewrite !big_ord_recr //= !big_ord0 !add0r //=.
+  + rewrite big_ord_recr //=.  apply addr_ge0.
+    - apply IHn'. intros. apply H.
+    - apply H.
+Qed.
 
 Lemma error_sum_le :
   forall k er er',  
@@ -550,4 +754,96 @@ rewrite IHk.
 rewrite S_INR; auto.
 Qed.
 
+Lemma maxr_both_le (x y z : R) :
+  x <= z -> y <= z -> (maxr x y) <= z.
+Proof.
+  intros. unfold maxr. destruct (x < y) eqn:E; auto.
+Qed.
+
+Lemma ltS_nat (x y : N) :
+  (x < y)%N -> (x.+1 < y.+1)%N.
+Proof.
+  intros. rewrite //=.
+Qed.
+
+Lemma bigmaxrP_le (x0 : R) lr (x : R) :
+  x0 <= x ->
+  (forall i : nat, (i < size lr)%N -> nth x0 lr i <= x) ->
+  \big[maxr / head x0 lr]_(i <- lr) i <= x.
+Proof.
+  intros. revert x H H0. induction lr as [|r0 lr']; intros.
+  + rewrite //= big_nil //=.
+  + rewrite //= big_cons. apply maxr_both_le.
+    { apply (H0 0). rewrite //=. }
+    destruct lr' as [|r1 lr'].
+    { rewrite //= big_nil //=. apply (H0 0). by []. }
+    simpl in *. assert (\big[maxr/r1]_(i <- (r1 :: lr')) i <= x).
+    { apply IHlr'; auto. intros. specialize (H0 i.+1).
+      apply H0. rewrite //=. }
+    rewrite big_cons. rewrite big_cons in H1.
+Abort.
+
+Lemma zero_vec_entry {n : nat} :
+  forall (i : 'I_n.+1), (0 : 'cV[R]_n.+1) i 0 = 0.
+Proof.
+  intros. rewrite /GRing.zero //= mxE //=.
+Qed.
+
+Lemma seq_const_nseq {A : Type} {B : Type} {n : nat} (a : A) (l : seq B) :
+  size l = n.+1 ->
+  [seq a | _ <- l] = nseq n.+1 a.
+Proof.
+  revert n. induction l as [|h t]; intros.
+  + rewrite //=.
+  + rewrite //= in H. inversion H.
+    destruct t as [|h' t'].
+    - rewrite //=.
+    - pose proof (IHt (length t')).
+      rewrite //=. rewrite //= in H0. f_equal. apply H0. auto.
+Qed.
+
+Lemma enum_inord {n : nat} (i : nat) :
+  (i < n.+1)%N -> (enum 'I_n.+1)`_i = inord i.
+Proof.
+  intros.
+  pose proof (@nth_ord_enum n.+1 GRing.zero (inord i)). 
+  rewrite -H0 //=. 
+  rewrite inordK; auto.
+Qed.
+
+Lemma bigmax_const_seq (m n : nat) (a : R) :
+  (0 < a)%Re ->
+  \big[maxr/0%Re]_(i <- [seq a | _ <- iota m n.+1]) i = a.
+Proof.
+  intros. revert m. induction n as [|n'].
+  + rewrite //= big_cons big_nil.
+    intros. rewrite /maxr. destruct (a < 0%Re) eqn:E.
+    - move /RltP in E. nra.
+    - reflexivity.
+  + intros. rewrite //= !big_cons //=.
+    rewrite //= in IHn'. specialize (IHn' m.+1).
+    rewrite big_cons in IHn'. rewrite IHn'. 
+    rewrite /maxr. destruct (a < a) eqn:E.
+    { move /RltP in E. nra. } reflexivity.
+Qed.
+
+
+(* Lemma sum_abs {n : nat} (f : 'I_n.+1 -> R) :
+  Rabs (\sum_i f i) <= \sum_i Rabs (f i).
+Proof.
+  revert n f. induction n as [|n']; intros.
+  + rewrite !big_ord_recr //= !big_ord0 -RplusE.
+    apply /RleP. apply Rle_trans with (Rabs 0 + Rabs (f ord_max)).
+    { apply Rabs_triang. }
+    rewrite -!RplusE. apply Rplus_le_compat_r. rewrite Rabs_R0. apply Rle_refl.
+  + rewrite big_ord_recr //=. 
+    assert (\sum_(i < n'.+2)  Rabs (f i) = \sum_(i < n'.+1)  Rabs (f (widen_ord (leqnSn n'.+1) i)) + Rabs (f ord_max)).
+    { rewrite big_ord_recr //=. }
+    rewrite {}H.
+    apply /RleP. rewrite -!RplusE.
+    eapply Rle_trans. { apply Rabs_triang. }
+
+    apply Rplus_le_compat_r. 
+    remember (fun i => (f (widen_ord (leqnSn n'.+1) i))) as g.
+    specialize (IHn' g). *)
 

--- a/norm_compat.v
+++ b/norm_compat.v
@@ -40,30 +40,25 @@ unfold vec_norm2, vec_inf_norm.
 match goal with |-context[(_ <= _ * ?a)%Re]=>
   replace a with (sqrt (Rsqr a)) 
 end.
-+ rewrite -sqrt_mult_alt.
-  - apply sqrt_le_1_alt . rewrite -sum_const .
+{ rewrite -sqrt_mult_alt.
+  + apply sqrt_le_1_alt. rewrite -sum_const.
     apply /RleP. apply big_sum_ge_ex_abstract.
-    intros. rewrite Rsqr_abs. apply  Rsqr_incr_1.
-    * apply Rle_trans with 
-      [seq Rabs (v i0 0) | i0 <- enum 'I_n.+1]`_i.
-      ++ rewrite seq_equiv. rewrite nth_mkseq. 
-         rewrite inord_val. apply Rle_refl.
-         apply ltn_ord.
-      ++ apply /RleP. 
-         apply (@bigmaxr_ler _ 0%Re 
-                    [seq Rabs (v i0 0) | i0 <- enum 'I_n.+1] i).
-    * rewrite size_map size_enum_ord. apply ltn_ord.
-    * apply Rabs_pos.
-  - apply /RleP. apply bigmax_le_0. apply /RleP. apply Rle_refl.
-    intros. rewrite seq_equiv. rewrite nth_mkseq;
-    last by rewrite size_map size_enum_ord in H0.
-    apply /RleP. apply Rabs_pos.
-  - apply pos_INR.
-+ apply sqrt_Rsqr. apply /RleP. apply bigmax_le_0.
-  - apply /RleP. apply Rle_refl.
-  - intros. rewrite seq_equiv. rewrite nth_mkseq;
-    last by rewrite size_map size_enum_ord in H.
-    apply /RleP. apply Rabs_pos.
+    intros. rewrite Rsqr_abs. apply Rsqr_incr_1.
+    2:{ apply Rabs_pos. }
+    { apply Rle_trans with [seq Rabs (v i0 0) | i0 <- enum 'I_n.+1]`_i. 
+      + rewrite seq_equiv nth_mkseq.
+        rewrite inord_val. apply Rle_refl. apply ltn_ord.
+      + apply bigmax_ler_0head. apply mem_nth. rewrite size_map size_enum_ord.
+        apply ltn_ord. intros. move /mapP in H0. destruct H0 as [i0 H0 H1]. rewrite H1.
+        apply /RleP. apply Rabs_pos. }
+    { apply /RleP. apply bigmax_le_0_0head. intros.
+      rewrite (@nth_map _ (@ord0 n) _ (@GRing.zero (Num_POrderedZmodule__to__GRing_Nmodule RbaseSymbolsImpl_R__canonical__Num_POrderedZmodule))).
+      apply /RleP. apply Rabs_pos. rewrite size_map in H0. auto. }
+  + apply pos_INR. }
+apply sqrt_Rsqr. apply /RleP. apply bigmax_le_0_0head.
+intros.
+rewrite (@nth_map _ (@ord0 n) _ (@GRing.zero (Num_POrderedZmodule__to__GRing_Nmodule RbaseSymbolsImpl_R__canonical__Num_POrderedZmodule))).
+apply /RleP. apply Rabs_pos. rewrite size_map in H. auto.
 Qed.
 
 Require Import floatlib fma_floating_point_model common 


### PR DESCRIPTION
Changed definitions using bigmaxr, deprecated in current Coq and mathcomp version.
Fixed proofs using the old definitions.